### PR TITLE
fix(ci): allowedTools 에 Read/Grep/Glob 추가 (권한 거부로 리뷰 중단)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -80,16 +80,23 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # ⚠️ --allowedTools 에 mcp__github_inline_comment__ 접두사 도구가 없으면
-          #    액션이 해당 MCP 서버를 **설치조차 하지 않습니다**(src/mcp/install-mcp-server.ts).
-          #    그러면 Claude는 분석만 하고 게시 수단이 없어 stdout으로 끝납니다 —
-          #    실측으로 두 번(커스텀 프롬프트 $0.19, code-review 플러그인 $2.00) 이 상태였습니다.
+          show_full_output: "true"
+          # ⚠️ --allowedTools 는 **배타적 허용 목록**입니다. 여기 없는 도구는 거부됩니다.
+          #    두 가지를 동시에 만족해야 합니다:
+          #    (1) mcp__github_inline_comment__ 접두사 도구가 있어야 액션이 해당 MCP 서버를
+          #        **설치합니다**(src/mcp/install-mcp-server.ts). 없으면 게시 수단 자체가 없습니다.
+          #    (2) Read / Grep / Glob 이 있어야 코드를 읽습니다. 공식 예시에는 이 셋이 없는데,
+          #        그 예시는 `gh pr diff` 만으로 끝나는 리뷰를 전제합니다. 우리 프롬프트는
+          #        AGENTS.md 규약과 파일을 가로지르는 정합성을 보므로 읽기 도구가 필요합니다.
+          #    실측: 셋을 빼면 permission_denials_count: 2 가 뜨고 6초 만에 포기합니다.
           #    이 줄과 아래 프롬프트의 "게시하라" 지시는 한 쌍입니다. 하나만 있으면 동작하지 않습니다.
+          # 🔎 show_full_output: 진단용 임시 설정입니다. 이번 검증이 끝나면 되돌리세요 —
+          #    켜 두면 리뷰 전문이 공개 Actions 로그에 남습니다.
           claude_args: |
             --model claude-sonnet-5
             --effort medium
             --max-turns 20
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
           # ⚠️ 스타일·포맷·타입을 지적하게 두지 마세요. ruff / mypy / reviewdog가 이미
           #    결정론적으로 판정하므로, LLM이 같은 주제로 코멘트하면 서로 충돌하는 조언이 되어
           #    사람이 어느 쪽을 따를지 잃습니다. 그 순간 팀은 봇 코멘트 전체를 무시하기 시작합니다.


### PR DESCRIPTION
## 📌 근본 원인 (실측)

```json
{ "is_error": false, "duration_ms": 6146, "num_turns": 5,
  "total_cost_usd": 0.1353661, "permission_denials_count": 2 }
```

**`--allowedTools` 는 배타적 허용 목록입니다.** PR #4에서 공식 예시를 그대로 따라 4개만 넣었더니, Claude가 코드를 읽으려던 도구 2건이 **거부**되어 6초 만에 포기했습니다.

공식 예시에 `Read`/`Grep`/`Glob` 이 없는 이유는 그 예시가 **`gh pr diff` 만으로 끝나는 리뷰**를 전제하기 때문입니다. 우리 프롬프트는 `AGENTS.md` 규약과 파일을 가로지르는 정합성(예: `ci.yml` 잡 이름 ↔ `setup-github.sh` contexts)을 보므로 읽기 도구가 필요합니다.

## 변경

- `--allowedTools` 에 `Read,Grep,Glob` 추가
- `show_full_output: "true"` **임시** 추가 — 이번에도 실패하면 추측 없이 원인을 보기 위해서입니다. 검증이 끝나면 되돌립니다(켜 두면 리뷰 전문이 공개 로그에 남습니다)

## 시도 이력

| # | 조치 | 결과 | 비용 |
|---|---|---|---|
| 1 | 커스텀 프롬프트 | 게시 0건 | $0.19 |
| 2 | code-review 플러그인 | 게시 0건 | $2.00 |
| 3 | allowedTools 4개 | 권한 거부 2건, 6초 포기 | $0.14 |
| **4** | **+ Read/Grep/Glob** | ← 이번 PR | — |

누적 **$2.33**.

---

## 📋 변경 유형

- [x] 🐛 버그 수정
- [x] 🔧 설정 / 환경