### PR TITLE
chore: 원전 템플릿의 개선사항 역반영 - gitleaks 핀 단일화 + .sh 개행 고정

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,13 @@
 *.ipynb filter=nbstripout
 *.zpln filter=nbstripout
 *.ipynb diff=ipynb
+
+# 셸 스크립트는 Windows에서도 LF로 체크아웃되어야 합니다. core.autocrlf=true 로 받으면
+# bash가 `set -o pipefail\r`를 알 수 없는 옵션으로 읽고 중단하므로, scripts/run-tests.sh가
+# 품질 게이트를 돌리기 전에 죽습니다. 이 줄은 **신규 클론**을 막아 줍니다 —
+# 각자에게 autocrlf를 바꾸라고 안내하는 것으로는 막히지 않습니다.
+#
+# ⚠️ 기존 클론은 이 줄로 고쳐지지 않습니다. 저장소 blob이 이미 LF라 git이 차이를 보지 못해
+# 작업트리 파일을 다시 쓰지 않습니다. 기존 클론의 복구는 .sh 파일을 지웠다가 다시 받거나
+# scripts/setup-dev.ps1을 한 번 실행하는 것입니다 — docs/공통_가이드/환경_세팅_가이드.md E12 참고.
+*.sh text eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,10 +53,16 @@ updates:
   # 아무도 그 사실을 알 수 없었습니다. 이제는 pre-commit의 `ruff-sync` 훅이 드리프트를
   # 막지만, 그건 "실패시키는" 장치일 뿐이라 rev를 실제로 올려줄 주체가 따로 필요합니다.
   #
-  # ⚠️ 그래도 ruff 상향은 여전히 **두 개의 PR**로 도착합니다(pip 하나, pre-commit 하나).
-  #    `ruff-sync` 훅 때문에 먼저 도착한 쪽은 CI에서 실패합니다 — 이는 설계된 동작입니다.
-  #    한쪽 PR 브랜치에서 나머지 파일까지 함께 고쳐 하나로 합쳐 머지하세요.
+  # ⚠️ 그래도 ruff 상향은 여전히 **세 개의 PR**로 도착합니다(pip 두 개 = 앱별 디렉토리,
+  #    pre-commit 하나). `ruff-sync` 훅 때문에 셋 중 무엇도 단독으로는 CI를 통과하지 못합니다 —
+  #    이는 설계된 동작입니다. 게다가 reviewdog.yml의 RUFF_VERSION은 어느 생태계에도 속하지
+  #    않아 아무도 올려주지 않으므로, 어차피 손으로 한 번은 합쳐야 합니다.
+  #    한쪽 PR 브랜치에서 나머지 파일까지 함께 고쳐 하나로 합쳐 머지하세요(실제 사례: #8).
+  #    절차는 docs/TEMPLATE_GUIDE.md의 함정 목록 참고.
   #    (Dependabot의 크로스 생태계 그룹화는 지원되지 않습니다 — 확실한 사실.)
+  #    ruff 외의 훅은 이 블록이 여는 PR **하나로 완결**됩니다. gitleaks도 예외였으나
+  #    (ci.yml이 버전을 따로 적어두고 있었음) ci.yml이 rev를 읽어가도록 바꿔 짝을 없앴습니다.
+  # 확실한 사실: 이 생태계는 version updates만 지원하고 security updates는 지원하지 않습니다.
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
@@ -70,7 +76,8 @@ updates:
         patterns: ["*"]
 
   # ── 프론트엔드: package.json이 없는 디렉토리를 등록하면 Dependabot이 매주 파싱 오류를
-  #    기록합니다. 스캐폴딩(P1, 이진호) 후 아래 블록의 주석을 해제하세요.
+  #    기록합니다. 프론트엔드 스캐폴딩이 끝난 뒤 아래 블록의 주석을 해제하세요.
+  #    ⚠️ 켜는 시점은 프론트엔드 오너(06)의 판단입니다 — 스프린트 중에는 PR 소음과의 트레이드오프입니다.
   # - package-ecosystem: "npm"
   #   directory: "/apps/frontend"
   #   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,26 @@ jobs:
       #    `--staged` 고정이라 CI에는 staged 변경이 없기 때문입니다. 그래서 여기서
       #    전체 트리를 따로 스캔합니다. 이 스텝을 지우면 로컬 훅을 설치하지 않은 사람의
       #    API 키 커밋을 아무도 막지 못합니다 (GitHub secret scanning은 제휴 발급사
-      #    패턴만 보므로 카카오/HyperCLOVA X 키는 사각지대 — 추정).
-      # 버전은 .pre-commit-config.yaml의 rev와 맞춰 함께 올리세요.
+      #    패턴만 보므로 국내 SaaS·자체 발급 키는 사각지대 — 추정).
+      # 버전은 .pre-commit-config.yaml의 gitleaks rev에서 **읽어옵니다** — 여기에 숫자를
+      #    다시 적어두면 훅과 CI가 서로 다른 gitleaks를 쓰는 드리프트가 언제든 생깁니다
+      #    (ruff가 실제로 그렇게 어긋난 적이 있습니다). 핀은 한 군데에만 둡니다.
       - name: gitleaks 전체 트리 스캔
-        env:
-          GITLEAKS_VERSION: 8.30.1
         run: |
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          # PyYAML은 위 `pip install pre-commit`이 의존성으로 끌어오므로 추가 설치 불필요.
+          version="$(python3 - <<'PY'
+          import sys
+
+          import yaml
+
+          repos = yaml.safe_load(open(".pre-commit-config.yaml"))["repos"]
+          revs = [r["rev"] for r in repos if "gitleaks/gitleaks" in r.get("repo", "")]
+          if len(revs) != 1:
+              sys.exit(f"expected exactly one gitleaks repo entry, found {revs}")
+          print(revs[0].removeprefix("v"))
+          PY
+          )"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz" \
             | tar -xz -C /usr/local/bin gitleaks
           # --redact: 탐지된 값이 공개 CI 로그에 그대로 남는 2차 유출을 막는다.
           gitleaks dir . --redact --verbose

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -74,8 +74,8 @@ jobs:
         if: always()
         run: docker rm -f "smoke-${{ matrix.app }}" 2>/dev/null || true
 
-  # docker-compose는 infra/에 아직 없습니다(P1, 김도혁). 파일이 생기면 자동으로 활성화됩니다.
-  # S1-1 DoD "docker-compose up으로 빈 서비스 기동"의 최소 회귀 검사입니다.
+  # infra/docker-compose.yml이 없는 단계에서도 안전하게 통과하고, 파일이 생기면 자동 활성화됩니다.
+  # "docker-compose up으로 서비스가 뜬다"의 최소 회귀 검사입니다.
   compose:
     name: docker-compose config 검증
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install harness
         run: pip install -r e2e/requirements.txt
 
-      # 스택 기동: infra/docker-compose.yml이 생기는 순간 자동으로 활성화됩니다(P1, 김도혁).
+      # 스택 기동: infra/docker-compose.yml이 생기는 순간 자동으로 활성화됩니다.
       # 그 전까지는 E2E_BASE_URL이 비어 있어 모든 테스트가 skip → 잡은 초록입니다.
       # ⚠️ .env.example의 더미 값으로 뜨는 범위까지만 검증됩니다. 실제 외부 API 키가 필요한
       #    시나리오는 secrets 등록 후에야 통과합니다 — non-required인 이유이기도 합니다.

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -5,9 +5,13 @@ name: Frontend CI
 #     docs/공통_가이드/저장소_운영.md §4의 알려진 함정. 파이썬 앱 CI만 required입니다.)
 #
 # 스캐폴딩 전 상태에서도 안전하게 통과합니다: apps/frontend/package.json이 생기기 전까지
-# 모든 단계가 건너뛰어집니다. 이진호(프론트엔드/UX)는 스캐폴딩 PR에서 아래를 확인만 하면 됩니다.
+# 모든 단계가 건너뛰어집니다. 프론트엔드 담당자(06)는 스캐폴딩 PR에서 아래를 확인하세요.
 #   - 패키지 매니저가 npm이 아니라면(pnpm/yarn) install 단계와 cache 설정을 교체
 #   - lint/build 스크립트 이름이 package.json에 존재하는지 (--if-present로 없으면 무시됨)
+#
+# ⚠️ 스캐폴딩이 끝나면 아래의 `if: hashFiles(...)` 조건과 `--if-present`를 **지우세요**.
+#    그대로 두면 스크립트가 사라지거나 이름이 바뀐 뒤에도 잡이 조용히 초록으로 통과합니다 —
+#    "아직 없어서 건너뜀"과 "없어져서 검사 안 됨"이 CI에서 구분되지 않기 때문입니다.
 on:
   pull_request:
     paths:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -28,8 +28,9 @@ permissions:
 
 env:
   # ⚠️ .pre-commit-config.yaml의 ruff rev, apps/*/pyproject.toml의 `ruff==` 와 **한 쌍**입니다.
-  #    (gitleaks의 rev ↔ ci.yml GITLEAKS_VERSION 과 같은 규약) 한쪽만 올리면 CI 게이트와
-  #    reviewdog가 서로 다른 규칙셋으로 같은 코드를 판정합니다.
+  #    한쪽만 올리면 CI 게이트와 reviewdog가 서로 다른 규칙셋으로 같은 코드를 판정합니다.
+  #    (gitleaks는 .pre-commit-config.yaml의 rev가 유일한 핀이라 이런 짝이 없습니다 —
+  #     ruff는 pip 설치 버전을 pyproject에 문자열로 박아야 해서 핀을 하나로 줄일 수 없습니다.)
   #    이 값은 pre-commit의 `ruff-sync` 훅(scripts/check_ruff_sync.py)이 검사 대상으로 읽습니다 —
   #    변수 이름을 바꾸면 그 스크립트도 함께 고쳐야 합니다.
   RUFF_VERSION: 0.16.1
@@ -145,6 +146,8 @@ jobs:
       - uses: actions/checkout@v7
 
       # frontend-ci.yml과 같은 규약: apps/frontend 스캐폴딩 전에는 모든 스텝이 건너뛰어집니다.
+      # ⚠️ 스캐폴딩이 끝나면 frontend-ci.yml과 **함께** 이 조건들을 지우세요. 그대로 두면
+      #    package-lock.json이 사라진 뒤에도 잡이 조용히 초록으로 통과합니다.
       - name: Skip notice (스캐폴딩 전)
         if: hashFiles('apps/frontend/package.json') == ''
         run: echo "apps/frontend/package.json이 아직 없습니다 - 프론트엔드 스캐폴딩 전이므로 건너뜁니다."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,15 @@ repos:
       - id: detect-private-key   # LLM 키/비밀키 평문 커밋 방지
 
   # gitleaks — API 키 평문 커밋 차단.
-  # 왜 필요한가: GitHub secret scanning은 "제휴 발급사 패턴"만 잡습니다. 이 프로젝트가 쓰는
-  # 카카오·HyperCLOVA X(NCP)·솔라피/알리고 키는 그 목록에 없을 가능성이 높고(추정),
+  # 왜 필요한가: GitHub secret scanning은 "제휴 발급사 패턴"만 잡습니다. 국내 SaaS나
+  # 자체 발급 API 키는 그 목록에 없을 가능성이 높고(추정),
   # 범용 패턴 탐지(non-provider patterns)는 GitHub Advanced Security 구독이 있어야 켜집니다.
   # 위 detect-private-key는 PEM 개인키만 잡으므로 API 키 문자열은 사각지대였습니다.
   # ⚠️ 이 훅은 **staged 변경만** 검사합니다(entry가 `--staged` 고정). 따라서
   #    `pre-commit run --all-files`(CI)에서는 아무것도 검사하지 않습니다 —
   #    CI의 전체 트리 스캔은 .github/workflows/ci.yml의 별도 스텝이 담당합니다. 둘은 한 쌍입니다.
+  # 아래 rev는 gitleaks 버전의 **유일한 핀**입니다 — CI 스캔 스텝이 이 값을 읽어 씁니다.
+  # 따라서 rev만 올리면 CI도 함께 따라옵니다(다른 파일을 같이 고칠 필요 없음).
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1
     hooks:
@@ -42,7 +44,8 @@ repos:
   # ruff — CI의 lint/format 게이트와 동일 검사 (pyproject [tool.ruff] 설정 공유).
   # ruff-check는 자동 수정(--fix), ruff-format은 자동 포맷.
   # ⚠️ 아래 rev는 apps/backend·apps/ai-engine의 dev extra `ruff==` 와 **한 쌍**입니다
-  #    (gitleaks의 rev ↔ ci.yml GITLEAKS_VERSION 규약과 동일). 이 잡과 CI의 lint 잡은
+  #    (gitleaks와 달리 이쪽은 CI가 rev를 읽어갈 수 없습니다 — pip가 설치 시점에 버전을 고정해야
+  #    하므로 핀이 pyproject 안에 문자열로 있어야 합니다). 이 잡과 CI의 lint 잡은
   #    서로 다른 경로로 ruff를 설치하므로, 한쪽만 올리면 같은 코드가 한쪽에서만 통과합니다.
   #    ruff는 0.x라 마이너 업그레이드에서 기본 규칙셋 자체가 넓어집니다 — 버전 상향은
   #    "린트 설정 변경"으로 취급해 네 파일(여기·apps/backend·apps/ai-engine·

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -76,14 +76,25 @@ compose가 생기는 순간 별도 설정 없이 활성화됩니다.
 `pre-commit run --all-files`(CI)로는 아무것도 검사하지 않기 때문입니다. 둘 중 하나만 남기면
 방어선이 사라집니다.
 
+다만 **버전 핀은 한 쌍이 아니라 한 곳**입니다. CI 스텝은 `.pre-commit-config.yaml`의 gitleaks
+`rev`를 읽어 그 버전을 내려받습니다. 워크플로에 버전을 다시 적어두면 훅과 CI가 서로 다른 gitleaks로
+같은 저장소를 판정하는 드리프트가 생기는데, ruff에서 실제로 그 일이 있었습니다.
+ruff는 pip가 설치 시점에 버전을 고정해야 해서 핀을 하나로 줄일 수 없고 — 그래서 `ruff-sync` 훅으로
+검사합니다 — gitleaks는 줄일 수 있어서 줄였습니다.
+
 ## 8. 왜 ruff `select`를 명시했나
 
 비워 두면 ruff의 기본 규칙셋을 상속하는데, ruff는 0.x라 마이너 업그레이드에서 기본값이 넓어집니다
 (실측: 0.15 통과 → 0.16에서 신규 검출 다수). 즉 버전을 올릴 때마다 린트 정책이 팀 의사와 무관하게
 바뀝니다. 명시하면 규칙 변경이 코드 리뷰를 거치는 **명시적 diff**가 됩니다.
 
-같은 이유로 ruff 버전은 세 곳(`.pre-commit-config.yaml` rev + 두 앱의 dev extra)에 **고정**돼 있고,
-그 셋은 항상 함께 올려야 합니다.
+같은 이유로 ruff 버전은 네 곳(`.pre-commit-config.yaml` rev + 두 앱의 dev extra +
+`reviewdog.yml`의 `RUFF_VERSION`)에 **고정**돼 있고, 그 넷은 항상 함께 올려야 합니다.
+지키라고 적어두는 것으로는 부족해서 `ruff-sync` 훅(`scripts/check_ruff_sync.py`)이 강제합니다 —
+Dependabot이 한 곳만 올린 PR이 실제로 드리프트를 만든 적이 있습니다.
+
+⚠️ 그 결과 **ruff 상향은 Dependabot PR 세 개로 도착하고, 셋 다 각각으로는 실패합니다.**
+합치는 절차는 [TEMPLATE_GUIDE.md](TEMPLATE_GUIDE.md)의 함정 목록에 있습니다.
 
 ## 9. 왜 문서 폴더만 한글인가
 

--- a/docs/TEMPLATE_GUIDE.md
+++ b/docs/TEMPLATE_GUIDE.md
@@ -83,11 +83,22 @@ bash scripts/setup-github.sh <owner>/<repo> --solo   # 1인: 승인 요구 제�
   `setup-github.sh`의 `contexts`를 **같은 PR에서** 함께 늘리세요. 매트릭스라 이름이 전개됩니다.
 - **앱을 추가할 때 고쳐야 하는 네 곳**: 루트 `pyproject.toml`의 ruff `src`(빠뜨리면 isort가 앱 내부
   import를 서드파티로 보고 CI가 I001로 실패), `ci.yml` matrix, `setup-github.sh` contexts, `CODEOWNERS`.
-- **ruff 버전은 세 곳이 한 쌍.** `.pre-commit-config.yaml`의 rev ↔ 두 앱의 dev extra `ruff==`.
+- **ruff 버전은 네 곳이 한 쌍.** `.pre-commit-config.yaml`의 rev ↔ 두 앱의 dev extra `ruff==`
+  ↔ `reviewdog.yml`의 `RUFF_VERSION`.
   ruff는 0.x라 마이너 업그레이드에서 기본 규칙셋이 넓어지므로, 한쪽만 올리면 같은 코드가 한쪽에서만
-  통과합니다. 버전 상향은 "린트 설정 변경"으로 취급해 세 파일을 같은 PR에서 올리세요.
+  통과합니다. 버전 상향은 "린트 설정 변경"으로 취급해 네 파일을 같은 PR에서 올리세요.
+  어긋난 채로는 `ruff-sync` 훅이 커밋도 CI도 막습니다.
+- **ruff 상향은 Dependabot PR 세 개로 도착합니다 — 하나로 합쳐서 머지하세요.**
+  Dependabot은 생태계 단위로만 PR을 나누므로 pre-commit rev 하나, 두 앱의 pip 하나씩이 따로 옵니다.
+  `reviewdog.yml`의 `RUFF_VERSION`은 어느 생태계에도 속하지 않아 **아무도 올려주지 않습니다.**
+  따라서 셋 중 무엇도 단독으로는 `ruff-sync`를 통과할 수 없습니다 — 실패는 설계된 동작입니다.
+  크로스 생태계 그룹화는 Dependabot이 지원하지 않으므로(확실한 사실), 한 PR의 브랜치에서
+  나머지 세 곳을 함께 올리고 남은 PR들은 닫으세요.
+  이 저장소에서 네 곳을 한 PR로 합쳐 올린 실제 사례는 #8(ruff 0.16.0 -> 0.16.1)입니다.
 - **gitleaks는 훅 + CI 두 개가 한 쌍.** 훅의 entry가 `--staged` 고정이라 `pre-commit run --all-files`는
   아무것도 검사하지 않습니다. CI의 전체 트리 스캔 스텝을 지우면 훅 미설치자의 키를 막을 수단이 없습니다.
+  단 **버전 핀은 `.pre-commit-config.yaml`의 rev 한 곳**입니다 — CI가 그 값을 읽어 씁니다.
+  워크플로에 버전을 다시 적지 마세요(ruff에서 실제로 생겼던 드리프트를 여기서는 구조적으로 없앴습니다).
 - **mypy·pytest는 앱 디렉토리를 cwd로** 실행해야 설정을 집습니다. 루트에서 `pytest apps/backend`로
   돌리면 testpaths·마커가 적용되지 않습니다.
 - **`from src.xxx` import 금지.** src 레이아웃에서 `src.` 접두어는 설치 환경에서 깨지는데 린트가

--- a/docs/공통_가이드/환경_세팅_가이드.md
+++ b/docs/공통_가이드/환경_세팅_가이드.md
@@ -59,7 +59,7 @@ cd AI10-Part4-3Team-Advanced-Project
 | E09 | **nbstripout git filter 등록** | FIX | `pip install nbstripout && python -m nbstripout --install` |
 | E10 | pre-commit 훅 환경 캐시 | FIX | `pre-commit install-hooks` |
 | E11 | `infra/.env` 존재 + git 무시 | FIX | `cp infra/.env.example infra/.env` |
-| E12 | 셸 스크립트 개행(LF) | FIX | `git config core.autocrlf input` 후 재체크아웃 |
+| E12 | 셸 스크립트 개행(LF) | FIX | `.sh` 삭제 후 재취득, 또는 `setup-dev.ps1` 1회 실행 |
 | W01 | gh CLI 인증 | WARN | `gh auth login` (admin만) |
 | W02 | docker + compose v2 | WARN | Docker Desktop / docker-ce (인프라) |
 | W03 | Node.js | WARN | LTS 설치 (프론트엔드) |
@@ -243,11 +243,19 @@ git config --get filter.nbstripout.clean                   # 등록 확인
 Windows에서 `core.autocrlf=true`로 체크아웃하면 `.sh` 파일에 CRLF가 들어가고,
 WSL·Git Bash에서 `$'\r': command not found` 또는 `bad interpreter`로 실패합니다.
 
+**신규 클론은 `.gitattributes`의 `*.sh text eol=lf`가 막아 줍니다.
+E12는 그 줄이 생기기 전에 만들어진 기존 클론의 복구 경로입니다.**
+
+주의: `git checkout`이나 `git add --renormalize`로는 고쳐지지 않습니다(실험으로 확인).
+저장소 blob이 원래 LF라 git이 차이를 감지하지 못해 작업트리 파일을 다시 쓰지 않기 때문입니다.
+유효한 복구는 파일을 실제로 없앴다가 받아오는 것뿐입니다.
+
 ```bash
-git config core.autocrlf input   # 커밋 시에만 정규화, 체크아웃 시 LF 유지
+rm scripts/*.sh && git checkout -- scripts/   # 삭제 후 재취득
 ```
 
-스크립트는 `scripts/*.sh`를 LF로 되돌립니다(원본 blob이 LF이므로 작업트리가 오히려 clean해집니다).
+주의: 저장소 원본으로 되돌리는 명령이라 `scripts/*.sh`에 커밋하지 않은 수정이 있으면 사라집니다.
+있다면 `setup-dev.ps1` 쪽을 쓰세요. 파일 안의 CRLF만 바꾸므로 수정이 보존됩니다.
 
 ## 6. 선택 항목 (WARN) — 담당 역할에서만 필요
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -26,6 +26,7 @@ docker compose -f infra/docker-compose.yml up --build
    CI의 전체 트리 스캔이 **한 쌍**입니다. 훅 entry가 `--staged` 고정이라
    `pre-commit run --all-files`로는 아무것도 검사하지 않으므로, CI 스텝을 지우면 훅을
    설치하지 않은 사람의 키를 아무도 막지 못합니다.
+   버전을 올릴 때는 `.pre-commit-config.yaml`의 rev만 고치면 됩니다 - CI가 그 값을 읽어 씁니다.
 
 ## 새 환경변수를 추가할 때
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ src = ["apps/backend/src", "apps/ai-engine/src", "training/src"]
 #    마이너 업그레이드에서 기본값이 넓어집니다(실측: 0.15 통과 → 0.16에서 신규 23건).
 #    즉 버전을 올릴 때마다 린트 정책이 우리 의사와 무관하게 바뀝니다. 아래 목록이 이제
 #    단일 원천이며, 규칙 추가/제거는 코드 리뷰를 거치는 명시적 변경이 됩니다.
-#    (버전 자체는 .pre-commit-config.yaml rev ↔ 앱 dev extra `ruff==` 로 고정 — 한 쌍입니다.)
+#    (버전 자체는 .pre-commit-config.yaml rev ↔ 두 앱의 dev extra `ruff==` ↔
+#     .github/workflows/reviewdog.yml의 RUFF_VERSION — 네 곳이 항상 같아야 하며,
+#     어긋나면 `ruff-sync` 훅이 막습니다. scripts/check_ruff_sync.py 참고.)
 [tool.ruff.lint]
 select = [
     # ── ruff 기본값 (pycodestyle 일부 + pyflakes). E501(줄 길이)은 formatter가

--- a/scripts/dev_env.py
+++ b/scripts/dev_env.py
@@ -508,16 +508,25 @@ def fix_env_file(ctx):
 # --- E12 line endings ---------------------------------------------
 
 
-SHELL_FILES = ("scripts/run-tests.sh", "scripts/setup-dev.sh", "scripts/setup-github.sh")
+# Discovered, not listed. A hardcoded tuple silently stops covering a script the moment
+# someone adds one — it had already drifted past scripts/apply-labels.sh. Every .sh in the
+# repo lives under scripts/, so a single glob is enough and costs no subprocess or tree walk.
+SHELL_DIR = "scripts"
+
+
+def _shell_files(ctx: Ctx):
+    try:
+        return sorted(p for p in ctx.path(SHELL_DIR).glob("*.sh") if p.is_file())
+    except OSError:
+        return []
 
 
 def _crlf_files(ctx: Ctx):
     bad = []
-    for rel in SHELL_FILES:
-        path = ctx.path(*rel.split("/"))
+    for path in _shell_files(ctx):
         try:
-            if path.exists() and b"\r\n" in path.read_bytes():
-                bad.append(rel)
+            if b"\r\n" in path.read_bytes():
+                bad.append(path.relative_to(ctx.root).as_posix())
         except OSError:
             continue
     return bad
@@ -533,10 +542,14 @@ def probe_line_endings(ctx):
 def fix_line_endings(ctx):
     # autocrlf=input keeps LF in the working tree while still normalising on commit.
     ok(["git", "config", "core.autocrlf", "input"], cwd=ctx.root)
-    for rel in _crlf_files(ctx):
-        path = ctx.path(*rel.split("/"))
+    # The bytes are rewritten directly rather than via git checkout on purpose: the blobs
+    # in the repo are already LF, so git sees no difference to restore and leaves a CRLF
+    # working copy untouched (`git status` stays clean while bash keeps failing).
+    for path in _shell_files(ctx):
         try:
-            path.write_bytes(path.read_bytes().replace(b"\r\n", b"\n"))
+            data = path.read_bytes()
+            if b"\r\n" in data:
+                path.write_bytes(data.replace(b"\r\n", b"\n"))
         except OSError:
             return False
     return True

--- a/scripts/dev_env.py
+++ b/scripts/dev_env.py
@@ -515,21 +515,40 @@ SHELL_DIR = "scripts"
 
 
 def _shell_files(ctx: Ctx):
+    # The glob only discovers names; each path is then re-derived from the literal root and
+    # required to resolve back into it. fix_line_endings rewrites bytes in place, so without
+    # this a symlink dropped into scripts/ would have it edit a file anywhere on disk -- a
+    # risk the previous hardcoded tuple did not carry. (Sonar flags the same shape as S2083.)
+    root = ctx.path(SHELL_DIR)
     try:
-        return sorted(p for p in ctx.path(SHELL_DIR).glob("*.sh") if p.is_file())
+        resolved_root = root.resolve()
+        names = sorted(p.name for p in root.glob("*.sh"))
     except OSError:
         return []
+    files = []
+    for name in names:
+        path = root / name
+        try:
+            if path.resolve().parent == resolved_root and path.is_file():
+                files.append(path)
+        except OSError:
+            continue
+    return files
 
 
-def _crlf_files(ctx: Ctx):
+def _crlf_paths(ctx: Ctx):
     bad = []
     for path in _shell_files(ctx):
         try:
             if b"\r\n" in path.read_bytes():
-                bad.append(path.relative_to(ctx.root).as_posix())
+                bad.append(path)
         except OSError:
             continue
     return bad
+
+
+def _crlf_files(ctx: Ctx):
+    return [p.relative_to(ctx.root).as_posix() for p in _crlf_paths(ctx)]
 
 
 def probe_line_endings(ctx):
@@ -545,11 +564,9 @@ def fix_line_endings(ctx):
     # The bytes are rewritten directly rather than via git checkout on purpose: the blobs
     # in the repo are already LF, so git sees no difference to restore and leaves a CRLF
     # working copy untouched (`git status` stays clean while bash keeps failing).
-    for path in _shell_files(ctx):
+    for path in _crlf_paths(ctx):
         try:
-            data = path.read_bytes()
-            if b"\r\n" in data:
-                path.write_bytes(data.replace(b"\r\n", b"\n"))
+            path.write_bytes(path.read_bytes().replace(b"\r\n", b"\n"))
         except OSError:
             return False
     return True


### PR DESCRIPTION
## 📌 변경 개요

원전 템플릿 [Yopkigom/ai-team-project-template](https://github.com/Yopkigom/ai-team-project-template)이 이 저장소 분기(`0520338`, 2026-08-01) 이후 받은 개선을 역반영합니다.

분기 이후 템플릿 커밋 3건을 검토했습니다.

| 템플릿 커밋 | 내용 | 판정 |
|---|---|---|
| [#9 `d9708a4`](https://github.com/Yopkigom/ai-team-project-template/pull/9) | 파생 프로젝트에서 검증된 GitHub 구성 개선 | 반영 |
| [#6 `9f43534`](https://github.com/Yopkigom/ai-team-project-template/pull/6) | ruff 0.16.1 상향 | 이미 적용됨 (이 저장소 #8이 네 곳을 동시에 맞춤) |
| [#10 `ef2e174`](https://github.com/Yopkigom/ai-team-project-template/pull/10) | 템플릿 보류 항목 정리 | 반영 (프로젝트 고유 주석은 제외) |

커밋은 둘입니다. 첫 커밋이 역반영이고, 둘째 커밋(아래 6번)은 **역반영이 만든 결함을 고치는 것**이라 되돌리지 않고 이 PR 안에 남겼습니다. 두 커밋을 나눈 이유는 squash 후에도 "왜 글롭 전환에 봉쇄 코드가 붙어 있는가"가 커밋 메시지에서 읽히게 하기 위함입니다.

### 1. gitleaks 버전 핀 단일화

`ci.yml`이 `GITLEAKS_VERSION`을 직접 적는 대신 `.pre-commit-config.yaml`의 `rev`를 읽어 씁니다.

두 곳에 숫자가 있으면 훅과 CI가 **서로 다른 gitleaks로 같은 저장소를 판정**하는 드리프트가 언제든 생깁니다. 이 저장소는 ruff에서 실제로 그 일을 겪었고(#8이 네 곳을 손으로 맞춰야 했던 이유), gitleaks는 구조적으로 없앨 수 있어서 없앴습니다. ruff는 pip가 설치 시점에 버전을 고정해야 해서 핀을 줄일 수 없으므로 `ruff-sync` 훅이 계속 담당합니다.

앞으로 gitleaks 상향은 `.pre-commit-config.yaml`의 `rev` 한 줄만 고치면 되고, Dependabot PR 하나로 완결됩니다.

### 2. `.gitattributes`에 `*.sh text eol=lf`

Windows에서 `core.autocrlf=true`로 체크아웃하면 bash가 `set -o pipefail\r`를 알 수 없는 옵션으로 읽고 중단해, `scripts/run-tests.sh`가 품질 게이트를 돌리기 전에 죽습니다. 이 줄은 **신규 클론**을 막습니다.

기존 클론의 복구 경로는 E12로 남기되, `git checkout`이나 `git add --renormalize`로는 고쳐지지 않는다는 사실(저장소 blob이 이미 LF라 git이 차이를 감지하지 못함)까지 문서화했습니다. 유효한 복구는 파일을 실제로 지웠다가 받아오거나 `setup-dev.ps1`을 한 번 돌리는 것뿐입니다.

### 3. `dev_env.py` E12가 글롭으로 발견

셸 스크립트를 하드코딩 튜플이 아니라 `scripts/*.sh` 글롭으로 찾습니다. 목록은 스크립트가 추가되는 순간 조용히 커버리지를 잃으며, **실제로 `apply-labels.sh`가 검사에서 빠져 있었습니다.**

`fix_line_endings`가 git이 아니라 바이트를 직접 다시 쓰는 이유도 주석으로 남겼습니다(위 2번과 같은 이유 - git은 되돌릴 차이를 못 봅니다).

### 4. ruff 핀 "세 곳" -> "네 곳" 정정

`reviewdog.yml`의 `RUFF_VERSION`이 도입된 뒤 갱신되지 않은 서술이 `pyproject.toml`, `DESIGN_DECISIONS.md`, `TEMPLATE_GUIDE.md` 세 곳에 남아 있었습니다. ruff 상향이 Dependabot PR 세 개로 도착하고 셋 다 각각으로는 `ruff-sync`에 막히는 이유를 바로 이 서술이 가리고 있었으므로, 합치는 절차와 함께 정정했습니다.

### 5. 원전의 파생 프로젝트 고유 정보 제거

워크플로와 설정 주석에 남아 있던 인명(`이진호`, `김도혁`)과 서비스명(`카카오`, `HyperCLOVA X`, `솔라피/알리고`)을 6곳에서 걷어내고 역할 번호로 바꿨습니다. 프론트엔드 조건부 스킵을 스캐폴딩 후 지우라는 경고를 `frontend-ci.yml`과 `reviewdog.yml` **양쪽에** 달았습니다 - 한쪽만 지우면 나머지 한쪽이 계속 조용히 초록으로 통과합니다.

### 6. (2번째 커밋) 글롭 전환이 만든 심볼릭 링크 추적 차단

위 3번을 그대로 반영한 첫 커밋이 Quality Gate를 떨어뜨렸습니다. **지적의 절반은 오탐이었지만 절반은 진짜였으므로, 억제가 아니라 수정으로 처리했습니다.**

`is_file()`은 심볼릭 링크를 따라갑니다. 그래서 `scripts/evil.sh -> /저장소밖/target.sh`가 있으면 `fix_line_endings`가 **저장소 밖 파일의 바이트를 제자리에서 다시 씁니다.** 쓰기 대상이 리터럴 세 개로 고정돼 있던 하드코딩 튜플에는 없던 위험이고, 글롭 전환이 만든 것이 맞습니다.

글롭은 이름 발견까지만 맡기고, 각 경로를 리터럴 root에서 다시 만든 뒤 `path.resolve().parent == root.resolve()`로 봉쇄했습니다. 함께 쓰기를 한 표현식으로 되돌리고 `_crlf_paths()`로 CRLF인 파일만 순회하게 했습니다 - "멀쩡한 파일은 다시 쓰지 않기"를 위해 넣었던 중간 변수가 사라지므로 같은 목적이 더 짧게 달성됩니다.

---

## 🔗 관련 이슈

- 해당 없음 (원전 템플릿 역반영)

---

## 📋 변경 유형

- [x] 🐛 버그 수정 (6번 - 역반영이 만든 심볼릭 링크 추적)
- [ ] ✨ 새 기능 / 모듈 추가
- [ ] 🔬 실험
- [ ] 📊 데이터 전처리 / 증강
- [x] 📝 문서 / 주석
- [x] 🔧 설정 / 환경
- [ ] ♻️ 리팩토링

---

## 🧪 테스트 / 검증 방법

로컬에서 확인함:

- `bash scripts/run-tests.sh` 통과 (backend 8 passed, ai-engine 25 passed, ruff/mypy 전항목 clean)
- `pre-commit run --all-files` 전항목 통과 (`ruff 버전 동기화 검사` 포함)
- `python3 scripts/dev_env.py --check` - E01~E12 전부 OK (E12 `LF 정상`), W04만 선택 경고
- 워크플로 YAML 9개 + `dependabot.yml` + `.pre-commit-config.yaml` 파싱 확인
- **`ci.yml`의 gitleaks 버전 추출 heredoc을 bash로 실제 실행해 `8.30.1`이 나오는 것까지 확인**했습니다. `.pre-commit-config.yaml`에 gitleaks 항목이 정확히 하나가 아니면 스크립트가 명시적으로 종료합니다.

**6번(심볼릭 링크 차단)은 재현으로 검증했습니다.** 임시 트리에 `scripts/crlf.sh`(CRLF), `scripts/lf.sh`(LF), `scripts/notshell.txt`, 그리고 저장소 밖을 가리키는 `scripts/evil.sh` 심볼릭 링크를 두고 돌렸습니다.

| 확인 항목 | 결과 |
|---|---|
| `_shell_files` 결과 | `crlf.sh`, `lf.sh` 만 (심볼릭 링크와 `.txt` 제외) |
| `probe_line_endings` | `BROKEN` -> 수리 -> `OK` |
| `crlf.sh` 내용 | `b'a\r\nb\r\n'` -> `b'a\nb\n'` |
| **저장소 밖 링크 대상** | **`b'SECRET\r\n'` 그대로 - 건드리지 않음** |

수정 후 CI 재실행에서 Quality Gate `OK`, `new_security_rating` 5 -> 1로 복귀했습니다.

---

## ⚠️ 리뷰어 주의사항

**`ci.yml`의 heredoc이 이 PR에서 가장 깨지기 쉬운 부분입니다.** `run: |` 블록 안의 `<<'PY'` 종료 토큰은 YAML 역들여쓰기 후 컬럼 0에 와야 합니다. 위에서 실행 검증했지만, 이 스텝을 손볼 때는 들여쓰기를 함께 보세요. PyYAML은 같은 잡의 `pip install pre-commit`이 의존성으로 끌어오므로 추가 설치가 없습니다 - 그 스텝을 지우면 이 스텝도 함께 깨집니다.

**`scripts/`가 커버리지 산정에서만 빠져 있다는 것이 이 PR에서 확인됐습니다.** 첫 커밋의 `dev_env.py` 변경이 `pythonsecurity:S2083`(BLOCKER)으로 잡혀 `new_security_rating`이 E가 됐고 Quality Gate가 실패했습니다. PR #18이 넣은 `sonar.coverage.exclusions=scripts/**`는 커버리지만 면제하고 버그·취약점 분석은 그대로 받는다는 서술([저장소_운영.md §8](docs/공통_가이드/저장소_운영.md))이 실제로 그렇게 동작합니다.

Sonar의 taint flow 설명 자체(`Source: a user can craft an HTTP request`)는 오탐입니다 - `dev_env.py`는 HTTP 표면이 없는 로컬 CLI이고, `scripts/`가 `sonar.sources`에 있어 웹 도달 가능 코드로 취급된 것입니다. 다만 그 오탐이 가리킨 자리에 진짜 결함(심볼릭 링크 추적)이 있었으므로 `# NOSONAR` 억제는 쓰지 않았습니다.

**`.gitattributes` 추가는 기존 클론에 아무 일도 하지 않습니다.** 머지 후 각자의 작업트리가 조용히 바뀌거나 하지 않으며, 반대로 이미 CRLF로 받아둔 사람은 여전히 E12 복구가 필요합니다. 이 저장소에서는 `git status`가 clean한 상태로 유지되는 것을 확인했습니다.

---

## 💬 기타

**템플릿에 없는 추가 정정 1건을 넣었습니다.** `dependabot.yml`의 "ruff 상향은 PR 두 개로 도착" 서술을 세 개로 고쳤습니다. pip 생태계는 앱 디렉토리별로 갈리므로 이 저장소에도 실제로 세 개(#8, #9, #10)가 왔고, 이 PR이 새로 반영하는 `TEMPLATE_GUIDE.md`의 "세 개" 서술과 모순되기 때문입니다.

**반영하지 않은 것**: 원전 #10은 루트 `pyproject.toml`의 `DTZ`/`LOG`/`S`/`T20` 주석에서 파생 프로젝트 고유 근거를 걷어냈지만, 이 저장소는 이미 광고 생성 프로젝트 기준으로 다시 쓴 상태입니다(생성 지연 p95, GCP VM은 UTC인데 팀은 KST로 읽음). 템플릿의 중립 서술로 되돌리면 근거가 오히려 약해지므로 현행 유지했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
