### PR TITLE
chore: CODEOWNERS 를 실제 계정으로 교체 (PM + TL 2인 공동 소유)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # CODEOWNERS — 경로별 기본 리뷰어 자동 배정.
 #
-# ⚠️ 이 파일은 **자리표시자 상태**입니다. `@role-*` 핸들은 실존하지 않는 계정이므로 현재
-#    아무것도 배정되지 않으며, `scripts/setup-github.sh`가 이를 감지해 코드오너 리뷰 요구를
-#    자동으로 꺼 둡니다(승인 가능한 오너가 0명이 되어 모든 PR이 영구 블록되는 사고 방지).
-#    2026-08-04 착수 회의에서 실제 GitHub ID로 교체한 뒤 setup-github.sh를 **재실행**하세요.
+# 현재 상태: PM(01)과 TL(02)의 GitHub ID만 확보되어 **전 경로를 두 사람이 공동 소유**합니다.
+#    나머지 세 명(03 AI, 05 백엔드, 06 프론트)의 ID가 들어오면 아래 "복원 대기" 블록을
+#    되살려 경로를 세분화하세요. 그때까지 세분화하면 실존하지 않는 계정이 섞여
+#    해당 경로의 실질 오너가 1명이 되고, 그 사람의 PR이 영구 블록됩니다.
 #
 # 교체 시 함께 고쳐야 하는 곳 (넷이 어긋나면 리뷰 배정이 조용히 실패합니다):
 #    이 파일 · AGENTS.md 팀 표 · docs/역할_가이드/README.md · docs/공통_가이드/개발자_가이드.md §5
@@ -16,6 +16,10 @@
 # ⚠️ 5명이 7역할을 겸임하므로, 한 사람이 같은 경로의 두 오너를 모두 맡는 조합이 생기지 않도록
 #    확인하세요 — 형식상 2명이지만 실질은 단독 소유가 되어 위 사고가 그대로 발생합니다.
 #
+# 이 파일을 머지한 뒤 **`bash scripts/setup-github.sh <org>/<repo>` 를 재실행**하세요.
+#    자리표시자 상태에서는 코드오너 리뷰 요구가 자동으로 꺼져 있습니다. 재실행 시 스크립트가
+#    기본 브랜치의 CODEOWNERS를 검증하고(오타·write 권한 누락), 문제가 없을 때만 켭니다.
+#
 # 위치: 레포 루트. GitHub은 루트 / .github/ / docs/ 중 **한 곳만** 읽으므로 사본을 만들지 마세요.
 # 문법: <경로 패턴> <@계정 또는 @org/팀>
 # ⚠️ 뒤에 오는 규칙이 앞을 덮어씁니다 — 더 좁은 경로를 아래쪽에 두세요.
@@ -24,28 +28,32 @@
 #   01 기획/총괄(PM)   02 테크리드      03 AI 생성·서빙   04 AI 학습·데이터
 #   05 백엔드/인프라   06 프론트엔드    07 QA/보안
 
-# 기본 소유자 — 계약·스캐폴딩을 총괄하는 사람(02) + 백업(01)
-*                            @role-lead @role-pm
+# 전 경로 — PM(01, 정승호) + TL(02, 신호정).
+# 필요 승인 1명이므로 평소에는 PM이 승인하고, PM이 작성자인 PR만 TL이 받습니다.
+*                            @wjdtmdgh87-lgtm @Yopkigom
 
-# 모듈 오너 (docs/역할_가이드/ 와 1:1) — 담당자 + 백업
-/apps/backend/               @role-backend @role-lead
-/apps/ai-engine/             @role-ai-serving @role-lead
-/apps/frontend/              @role-frontend @role-pm
-/training/                   @role-ai-training @role-ai-serving
-/packages/contracts/         @role-lead @role-backend
-/infra/                      @role-backend @role-lead
-/docs/adr/                   @role-lead @role-pm
-
+# ─────────────────────────────────────────────────────────────────────────────
+# 복원 대기 — 03 · 05 · 06 의 GitHub ID가 확보되면 아래를 되살리고 위 `*` 규칙은 남겨 둡니다.
+# (`*` 는 아래 규칙에 걸리지 않는 경로의 기본값 역할을 계속 합니다.)
+#
+# /apps/backend/               @role-backend @role-lead
+# /apps/ai-engine/             @role-ai-serving @role-lead
+# /apps/frontend/              @role-frontend @role-pm
+# /training/                   @role-ai-training @role-ai-serving
+# /packages/contracts/         @role-lead @role-backend
+# /infra/                      @role-backend @role-lead
+# /docs/adr/                   @role-lead @role-pm
+#
 # 평가 하네스는 ai-engine 소속이지만 채점 기준은 QA와 공동 소유 (자기채점 편향 방지).
 # ⚠️ 여기 오너가 03(생성)·04(학습)뿐이면 자기 결과의 채점 기준을 자기가 바꾸게 됩니다.
-/apps/ai-engine/eval/        @role-qa @role-ai-training
-
+# /apps/ai-engine/eval/        @role-qa @role-ai-training
+#
 # 앱을 가로지르는 관통 테스트 — 특정 앱이 아니라 QA 소유 (+ 백업)
-/e2e/                        @role-qa @role-pm
-
+# /e2e/                        @role-qa @role-pm
+#
 # 파이프라인·품질 게이트 변경은 영향 범위가 넓으므로 리드 + QA 동시 리뷰
-/.github/                    @role-lead @role-qa
-/scripts/                    @role-lead @role-qa
-
+# /.github/                    @role-lead @role-qa
+# /scripts/                    @role-lead @role-qa
+#
 # 학습 데이터의 권리 근거는 잘못되면 되돌릴 수 없으므로 PM 승인을 함께 건다
-/training/data/              @role-ai-training @role-pm
+# /training/data/              @role-ai-training @role-pm


### PR DESCRIPTION
## 📌 변경 개요

`CODEOWNERS` 의 자리표시자 `@role-*` 를 실제 GitHub 계정으로 교체합니다.
ID 가 확보된 두 명이 **전 경로를 공동 소유**합니다.

| 역할 | 이름 | GitHub ID |
|---|---|---|
| 01 PM | 정승호 | `@wjdtmdgh87-lgtm` |
| 02 TL | 신호정 | `@Yopkigom` |

경로별 세분화(03 AI / 05 백엔드 / 06 프론트)는 **하지 않았습니다.** 지금 세분화하면 실존하지
않는 계정이 섞여 그 경로의 실질 오너가 1명이 되고, 작성자 본인 승인은 카운트되지 않으므로
그 사람의 PR 이 영구 블록됩니다. 기존 역할 매핑은 "복원 대기" 블록에 주석으로 보존했으니,
나머지 세 명의 ID 가 들어오면 되살리면 됩니다.

기술문서 재작성 PR 들(용어 사전 -> 도메인 모델 -> API 계약 -> 생성 파이프라인 -> 구현 범위)이
뒤따릅니다. 그 PR 들의 리뷰 경로를 먼저 세우기 위한 선행 작업입니다.

---

## 🔗 관련 이슈

- Closes #

---

## 📋 변경 유형

- [x] 🔧 설정 / 환경

---

## 🧪 테스트 / 검증 방법

- `pre-commit` 훅 통과 (로컬에서 확인함)
- 머지 후 검증은 아래 "머지 직후 할 일" 참고

---

## ⚠️ 리뷰어 주의사항

**머지 직후 할 일 (TL)**

```bash
bash scripts/setup-github.sh Codeit-AI10-Part4-3Team/AI10-Part4-3Team-Advanced-Project
```

GitHub 은 **기본 브랜치의 CODEOWNERS 만** 읽으므로 머지 전에는 효력이 없습니다.
재실행하면 스크립트가 `repos/.../codeowners/errors` 로 오타와 write 권한 누락을 검증하고,
문제가 없을 때만 코드오너 리뷰 요구를 켭니다. 문제가 있으면 요구를 끈 채로 진행하므로
모든 PR 이 막히는 사고는 나지 않습니다.

**확인이 필요한 것**

- [x] `@wjdtmdgh87-lgtm` 계정이 이 저장소에 **write 권한**을 가지고 있는지
      (권한이 없으면 오너로 인정되지 않고 조용히 무시됩니다)

**아직 안 맞춘 곳**

`AGENTS.md` 팀 표 · `docs/역할_가이드/README.md` · `docs/공통_가이드/개발자_가이드.md` §5 는
여전히 TBD 입니다. 이 셋은 나머지 세 명의 ID 가 모이면 **한 PR 에서 함께** 채웁니다 —
지금 두 명만 부분 반영하면 문서 세 곳이 서로 다른 상태로 갈라집니다.

---

## 💬 기타

필요 승인 수는 1 입니다. 평소에는 PM 이 승인해 빠르게 돌고, PM 이 작성자인 PR 만 TL 이 받습니다.
