### PR TITLE
fix(ci): reviewdog eslint 를 pnpm 으로 - 무음 통과 차단

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -149,29 +149,33 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # frontend-ci.yml과 같은 규약: apps/frontend 스캐폴딩 전에는 모든 스텝이 건너뛰어집니다.
-      # ⚠️ 스캐폴딩이 끝나면 frontend-ci.yml과 **함께** 이 조건들을 지우세요. 그대로 두면
-      #    package-lock.json이 사라진 뒤에도 잡이 조용히 초록으로 통과합니다.
-      - name: Skip notice (스캐폴딩 전)
-        if: hashFiles('apps/frontend/package.json') == ''
-        run: echo "apps/frontend/package.json이 아직 없습니다 - 프론트엔드 스캐폴딩 전이므로 건너뜁니다."
+      # ⚠️ 스텝에 `if: hashFiles(...)` 게이트를 다시 붙이지 마세요. 예전에는 스캐폴딩 전을
+      #    대비해 package-lock.json 존재 여부로 걸어두었는데, 프론트엔드가 pnpm으로
+      #    스캐폴딩되면서 그 파일이 영영 생기지 않아 **모든 스텝이 skipped인 채 잡만 초록**이
+      #    됐습니다. 조건 없이 항상 도는 지금 형태가 그 무음 통과를 막는 유일한 장치입니다.
+      #    (frontend-ci.yml은 같은 정리를 스캐폴딩 시점에 이미 마쳤습니다.)
+      #
+      # ⚠️ pnpm 버전은 apps/frontend/package.json의 `packageManager`와 한 쌍입니다.
+      #    frontend-ci.yml의 pnpm/action-setup 핀도 같은 값이어야 합니다.
+      - uses: pnpm/action-setup@v6
+        with:
+          version: '11.19.0'
 
       - uses: actions/setup-node@v7
-        if: hashFiles('apps/frontend/package-lock.json') != ''
         with:
           node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: apps/frontend/package-lock.json
+          cache: 'pnpm'
+          cache-dependency-path: apps/frontend/pnpm-lock.yaml
 
       - name: Install
-        if: hashFiles('apps/frontend/package-lock.json') != ''
         working-directory: apps/frontend
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
-      # ⚠️ 이 액션은 eslint가 devDependencies에 설치돼 있어야 동작합니다.
-      #    패키지 매니저를 pnpm/yarn으로 바꾸면 위 install 스텝과 함께 교체하세요.
+      # ⚠️ 이 액션은 eslint가 node_modules에 이미 설치돼 있어야 합니다. 내부적으로
+      #    `npx --no-install eslint`로 찾고, 못 찾으면 `npm install`로 폴백해 pnpm 레포에
+      #    package-lock.json을 만들어버립니다. 위 Install 스텝을 지우면 그 폴백을 타므로
+      #    두 스텝은 한 쌍으로 취급하세요.
       - uses: reviewdog/action-eslint@v1
-        if: hashFiles('apps/frontend/package-lock.json') != ''
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review


### PR DESCRIPTION
## 📌 변경 개요

`reviewdog / eslint` 잡이 **모든 스텝이 skipped 인 채 success 로 보고**되고 있었습니다. 프론트엔드 eslint 인라인 코멘트가 지금까지 한 번도 달린 적이 없습니다.

원인은 스텝마다 걸린 `if: hashFiles('apps/frontend/package-lock.json') != ''` 입니다. 프론트엔드는 pnpm 으로 스캐폴딩되어 `package-lock.json` 이 생기지 않으므로 이 조건은 영원히 거짓입니다. 실제 실행 기록입니다 (job 95394900157):

```
success  Run actions/checkout@v7
skipped  Skip notice (스캐폴딩 전)
skipped  Run actions/setup-node@v7
skipped  Install
skipped  Run reviewdog/action-eslint@v1
success  Complete job          <- 결론: success
```

`Skip notice` 조차 `package.json` 이 존재해서 건너뛰기 때문에 로그에 아무 단서도 남지 않습니다.

이것은 워크플로 자신의 주석이 예고했던 상태입니다:

> ⚠️ 스캐폴딩이 끝나면 frontend-ci.yml 과 **함께** 이 조건들을 지우세요. 그대로 두면 package-lock.json 이 사라진 뒤에도 잡이 조용히 초록으로 통과합니다.

`frontend-ci.yml` 은 스캐폴딩 시점에 pnpm 으로 정리를 마쳤고, reviewdog 쪽만 남아 있었습니다. 정리가 절반만 된 드리프트입니다.

변경 내용입니다.

- `package-lock.json` 게이트 3개 제거, 무의미해진 `Skip notice` 스텝 제거
- `pnpm/action-setup@v6` (11.19.0) 추가
- 캐시 기준을 `apps/frontend/pnpm-lock.yaml` 로 변경
- `npm ci` -> `pnpm install --frozen-lockfile`

---

## 🔗 관련 이슈

- 없습니다. Dependabot PR 108 ~ 110 (프론트엔드 의존성 상향) 을 검토하다 발견했습니다.

---

## 📋 변경 유형

- [x] 🐛 버그 수정
- [ ] ✨ 새 기능 / 모듈 추가
- [ ] 🔬 실험
- [ ] 📊 데이터 전처리 / 증강
- [ ] 📝 문서 / 주석
- [x] 🔧 설정 / 환경
- [ ] ♻️ 리팩토링

---

## 🧪 테스트 / 검증 방법

로컬에서 확인한 것입니다.

- 결함 재현: `gh api .../actions/jobs/95394900157` 로 스텝별 결론을 조회해 위 skipped 목록을 확인했습니다.
- `package-lock.json` 이 추적 파일에 없음을 `git ls-files` 로 확인했습니다.
- 수정본 YAML 파싱 통과를 확인했습니다.
- `reviewdog/action-eslint@v1` 의 `script.sh` 를 직접 읽어 eslint 탐색 방식을 확인했습니다 (아래 주의사항 참고).

로컬에서 확인하지 못한 것입니다.

- actionlint 가 로컬에 없어 워크플로 문법 검증을 돌리지 못했습니다. 이 PR 의 `reviewdog / actionlint` 잡이 판정합니다.
- **이 PR 만으로는 실동작이 검증되지 않습니다.** 워크플로 파일만 바뀌어 eslint 가 지적할 프론트엔드 코드가 없기 때문입니다. 머지 후 PR #102 (로그인 화면) 를 리베이스하면 거기서 인라인 코멘트가 실제로 달리는지 확인할 수 있습니다.

---

## ⚠️ 리뷰어 주의사항

**1. Install 스텝과 action-eslint 는 한 쌍입니다.**

`action-eslint` 의 `script.sh` 는 eslint 를 이렇게 찾습니다.

```bash
if ! npx --no-install -c 'eslint --version'; then
  echo '::group:: Running `npm install` to install eslint ...'
  npm install
```

선행 설치 스텝을 지우면 이 폴백을 타서 **pnpm 레포에 `package-lock.json` 을 만들어버립니다.** 주석으로 남겨두었습니다.

**2. 게이트를 제거해 이 잡이 모든 PR 에서 항상 실행됩니다.**

파이썬만 바뀐 PR 에서도 pnpm 설치가 돕니다 (캐시 적중 시 1초 내외). 조건부 실행으로 되돌리고 싶으시면 `hashFiles` 대신 `dorny/paths-filter` 같은 명시적 경로 판정을 쓰는 편이 안전합니다. `hashFiles` 로 다시 거는 방식은 이번 결함의 원인이므로 피해주세요. 주석에도 적어두었습니다.

**3. pnpm 버전이 새로운 한 쌍이 됩니다.**

`pnpm/action-setup` 의 `version: '11.19.0'` 이 `apps/frontend/package.json` 의 `packageManager`, 그리고 `frontend-ci.yml` 의 같은 핀과 세 곳 한 쌍입니다. ruff 와 같은 구조인데 `check_ruff_sync.py` 같은 강제 장치는 없습니다. 지금은 세 값이 일치합니다.

---

## 💬 기타

`reviewdog / eslint` 는 의도적으로 non-required 이므로 이 변경이 required 체크 목록에 영향을 주지 않습니다 (`scripts/setup-github.sh` 확인).

이 잡이 살아나면 기존 프론트엔드 코드에 그동안 묻혀 있던 지적이 한 번에 드러날 수 있습니다. `filter_mode: added` 라 신규 변경 줄에만 코멘트가 달리므로 폭발하지는 않을 것으로 봅니다. 추정입니다.
