### PR TITLE
infra: VM 배포 절차를 스크립트로 고정 - scripts/deploy-vm.sh

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -139,7 +139,12 @@ ssh "$ADCRAFT_VM" 'cd ~/adcraft && bash scripts/deploy-vm.sh'
 | `bash scripts/deploy-vm.sh` | `origin/main`으로 fast-forward -> 이미지 재빌드 -> 스택 교체 -> 관통 확인 |
 | `bash scripts/deploy-vm.sh --ref <ref>` | 다른 브랜치·태그·커밋으로. **롤백도 이 경로입니다** |
 | `bash scripts/deploy-vm.sh --check` | 점검만. 아무것도 바꾸지 않습니다 |
-| `bash scripts/deploy-vm.sh --no-build` | 재빌드 없이 재기동. `.env`만 고쳤을 때 |
+| `bash scripts/deploy-vm.sh --no-build` | **체크아웃과 이미지를 그대로 두고** 재기동. `.env`만 고쳤을 때 |
+
+> ⚠️ **`--no-build`는 체크아웃을 갱신하지 않습니다**(`--ref`와 함께 쓸 수 없습니다). 코드를
+> 새 커밋으로 옮기면서 이미지를 옛것으로 두면, 실제로 도는 코드와 `git rev-parse HEAD`가
+> 어긋나 "VM에 뭐가 떠 있나"의 답이 조용히 거짓이 됩니다. 코드를 옮기는 경로는 재빌드하는
+> 쪽 하나뿐입니다 — 소스가 그대로면 레이어 캐시가 걸려 재빌드도 몇 초로 끝납니다.
 
 접속 정보(외부 IP · 프로젝트 ID · 인스턴스명)는 **스크립트에도 이 문서에도 적지 않습니다.**
 저장소가 public이기 때문이며, 접속 경로는

--- a/infra/README.md
+++ b/infra/README.md
@@ -123,6 +123,49 @@ ADGEN_ACCOUNTS=[{"loginId":"demo1","passwordHash":"$$argon2id$$v=19$$m=65536,t=3
 > `8000`을 함께 열어 둔 것은 `curl`로 계약을 직접 두드리는 경로를 남기기 위해서이며,
 > HTTPS 종단이 들어올 때 닫을지 함께 정합니다.
 
+### 배포 실행 절차 (`scripts/deploy-vm.sh`)
+
+SA 키를 발급할 수 없어 배포는 **SSH 수동 경로**입니다(아래 "배포 자동화" 참고). 그 절차를
+사람의 기억이 아니라 스크립트에 고정했습니다 — 손으로 치면 빠뜨리는 것이 매번 다릅니다.
+
+**VM 안에서** 실행합니다. 원격에서는 SSH로 감쌉니다:
+
+```bash
+ssh "$ADCRAFT_VM" 'cd ~/adcraft && bash scripts/deploy-vm.sh'
+```
+
+| 명령 | 하는 일 |
+|---|---|
+| `bash scripts/deploy-vm.sh` | `origin/main`으로 fast-forward -> 이미지 재빌드 -> 스택 교체 -> 관통 확인 |
+| `bash scripts/deploy-vm.sh --ref <ref>` | 다른 브랜치·태그·커밋으로. **롤백도 이 경로입니다** |
+| `bash scripts/deploy-vm.sh --check` | 점검만. 아무것도 바꾸지 않습니다 |
+| `bash scripts/deploy-vm.sh --no-build` | 재빌드 없이 재기동. `.env`만 고쳤을 때 |
+
+접속 정보(외부 IP · 프로젝트 ID · 인스턴스명)는 **스크립트에도 이 문서에도 적지 않습니다.**
+저장소가 public이기 때문이며, 접속 경로는
+[GCP_VM_사용_가이드.md](../docs/공통_가이드/GCP_VM_사용_가이드.md)에 있습니다.
+
+스크립트가 사람 대신 지키는 것은 넷입니다. 손으로 배포할 때도 같은 순서를 지키세요:
+
+- **`infra/.env` 없이 기동하지 않습니다.** 없으면 `ADGEN_ACCOUNTS`가 빈 문자열로 넘어가고,
+  `seed([])`는 아무것도 지우지 않으므로 **기동은 성공한 채 로그인만 어긋납니다.** 배포 실패로
+  보이지 않는 것이 이 함정의 전부입니다 (`apps/backend/tests/api/test_startup.py`).
+- **볼륨을 건드리는 플래그를 쓰지 않습니다.** `-v`는 스크립트 어디에도 없습니다 (아래 절).
+- **`git merge --ff-only`만 씁니다.** 배포 체크아웃에 머지 커밋이 생기면 "VM에 뭐가 떠 있나"를
+  커밋 SHA로 답할 수 없게 됩니다.
+- **`--wait`로 healthy를 확인하고, 실패하면 로그와 롤백 명령을 출력합니다.** 안 뜬 스택을
+  성공으로 보고하지 않기 위해서입니다.
+
+배포 후 확인 항목도 스크립트가 함께 찍습니다: 컨테이너 상태, `/data/adgen.sqlite` 보존,
+시드된 계정 건수(0건이면 로그인이 무조건 401), 생성 모드(`stub` / `model`), backend `/health`,
+frontend `/`, 그리고 프론트 프록시를 거친 `/v1/sessions`가 미인증 401을 돌려주는지.
+마지막 항목 하나가 라우팅 · 인증 · 에러 계약 셋을 한 번에 봅니다.
+
+> ⚠️ **HTTPS 종단이 붙기 전까지 브라우저 로그인은 성립하지 않습니다.** 세션 쿠키가 `Secure`
+> 고정인데(`apps/backend/src/api/routes/auth.py`) 평문 HTTP 응답의 쿠키는 브라우저가 저장하지
+> 않습니다. 이 배포의 검증 수단은 `curl`이며, 스크립트의 확인 항목도 그 전제로 짜여 있습니다
+> ([API_계약.md](../docs/기술문서/API_계약.md) 8.3절).
+
 ### 상태는 `adgen-state` 볼륨 안에 있습니다
 
 계정·세션이 든 SQLite 파일은 컨테이너의 `/data`에 있고, 그 경로에는 이름 있는 볼륨
@@ -220,7 +263,8 @@ status check 로 지정할 수 없습니다(그 조합은 해당 경로 변경�
 없습니다.** 따라서:
 
 - GitHub Actions에서 SA 키로 VM에 배포하는 경로는 **성립하지 않습니다.** 계획에 넣지 마세요.
-- 배포는 SSH 접속 후 `git pull` + `docker compose up` 수동 경로입니다. 절차를 이 문서에 남기세요.
+- 배포는 SSH 접속 후 `git pull` + `docker compose up` 수동 경로입니다. 그 절차는
+  `scripts/deploy-vm.sh`에 고정했습니다 — 위 "배포 실행 절차" 참고.
 - **VM에 붙은 서비스 계정으로 VM 안에서 GCP API를 쓰는 것은 영향받지 않습니다.** 메타데이터
   서버가 토큰을 주므로 키가 필요 없습니다. 막힌 것은 키를 **VM 밖으로 꺼내는 일**입니다.
 

--- a/scripts/deploy-vm.sh
+++ b/scripts/deploy-vm.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# GCP VM 배포 — 체크아웃을 목표 ref 로 올리고 compose 스택을 교체한 뒤 관통 확인까지 합니다.
+# **VM 안에서** 실행합니다. 로컬에서 원격으로 돌릴 때는 SSH 로 감싸세요:
+#
+#     ssh "$ADCRAFT_VM" 'cd ~/adcraft && bash scripts/deploy-vm.sh'
+#
+# ⚠️ 접속 정보(외부 IP·프로젝트 ID·인스턴스명)를 이 파일에 적지 마세요 — 저장소가 public 입니다.
+#    접속 경로는 docs/공통_가이드/GCP_VM_사용_가이드.md, 권한 경계는 ADR-0011 에 있습니다.
+#
+# ⚠️ 볼륨은 어떤 경우에도 건드리지 않습니다. `down -v` 도 `up -v` 도 없습니다 — `adgen-state`
+#    에 계정과 세션이 들어 있고(ADR-0014), 지우면 되돌리는 방법은 백업뿐입니다. 이 스크립트가
+#    컨테이너를 재생성해도 볼륨은 그대로 살아남습니다.
+#
+# ⚠️ 배포 자동화(GitHub Actions)는 성립하지 않습니다 — SA 키 발급이 조직 정책으로 막혀 있어
+#    수동 SSH 경로가 유일합니다(ADR-0011). 이 스크립트는 그 수동 절차를 고정한 것입니다.
+#
+# 사용: bash scripts/deploy-vm.sh                 origin/main 으로 배포 (재빌드 포함)
+#       bash scripts/deploy-vm.sh --ref <ref>     다른 브랜치·태그·커밋으로 배포
+#       bash scripts/deploy-vm.sh --check         점검만 (fetch·빌드·기동 없음)
+#       bash scripts/deploy-vm.sh --no-build      코드 갱신 없이 재기동만 (.env 변경 반영 등)
+#       bash scripts/deploy-vm.sh --skip-verify   배포 후 관통 확인 생략
+# ⚠️ -E(errtrace) 가 있어야 ERR 트랩이 함수 안까지 따라갑니다. 없으면 실패한 배포가 로그도
+#    롤백 안내도 없이 조용히 끝납니다 — 이 스크립트의 실패 처리는 전부 함수 안에서 납니다.
+set -Eeuo pipefail
+
+# ⚠️ 전체를 함수로 감싸고 마지막 줄에서 호출합니다. 이 스크립트는 **자기 자신이 들어 있는
+#    체크아웃을 갱신**하므로, 실행 도중 `git merge` 가 이 파일을 바꿉니다. bash 는 스크립트를
+#    파일 오프셋 기준으로 이어 읽기 때문에, 평범하게 위에서 아래로 쓴 스크립트는 그 순간
+#    엉뚱한 지점을 실행합니다. 마지막 줄까지 파싱을 끝낸 뒤 실행에 들어가면 그 창이 닫힙니다.
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMPOSE_FILE="infra/docker-compose.yml"
+ENV_FILE="infra/.env"
+
+# compose 의 포트 매핑과 같아야 합니다. 바꿀 일이 생기면 compose 쪽이 정본입니다.
+FRONTEND_PORT="${ADCRAFT_FRONTEND_PORT:-80}"
+BACKEND_PORT="${ADCRAFT_BACKEND_PORT:-8000}"
+
+# 이 아래로 여유가 없으면 빌드 도중 죽습니다. 이미지 3종 재빌드에 수 GB 가 듭니다.
+DISK_WARN_GB=10
+
+REF="main"
+MODE="deploy"
+DO_BUILD=1
+DO_VERIFY=1
+
+log()  { echo "==> $*"; }
+warn() { echo "  ! $*" >&2; }
+die()  { echo "[중단] $*" >&2; exit 1; }
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --ref)         REF="${2:?--ref 뒤에 브랜치·태그·커밋이 필요합니다}"; shift 2 ;;
+      --check)       MODE="check"; shift ;;
+      --no-build)    DO_BUILD=0; shift ;;
+      --skip-verify) DO_VERIFY=0; shift ;;
+      -h|--help)     sed -n '1,25p' "$0"; exit 0 ;;
+      *)             die "모르는 인자: $1 (사용법은 --help)" ;;
+    esac
+  done
+}
+
+compose() {
+  docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" "$@"
+}
+
+preflight() {
+  log "사전 점검"
+
+  [[ -f "$COMPOSE_FILE" ]] || die "$COMPOSE_FILE 이 없습니다. 레포 루트에서 실행하세요."
+  command -v docker >/dev/null 2>&1 || die "docker 가 없습니다."
+  docker compose version >/dev/null 2>&1 || die "docker compose v2 가 없습니다."
+
+  # ⚠️ .env 없이 뜨는 것을 막습니다. compose 가 `${ADGEN_ACCOUNTS:-}` 를 빈 문자열로 넘기면
+  #    시드가 0건이 되는데, seed([]) 는 아무것도 지우지 않아 **기존 계정은 남고 기동은
+  #    성공**합니다. 증상은 배포 실패가 아니라 "로그인만 이상함"으로 나옵니다
+  #    (apps/backend/tests/api/test_startup.py 의 회귀 테스트가 이 시나리오입니다).
+  [[ -f "$ENV_FILE" ]] || die "$ENV_FILE 이 없습니다. 이 파일 없이 배포하면 인증이 조용히 어긋납니다."
+  grep -q '^ADGEN_ACCOUNTS=' "$ENV_FILE" || warn "$ENV_FILE 에 ADGEN_ACCOUNTS 가 없습니다 — 로그인이 성립하지 않습니다."
+  grep -q '^ADGEN_SESSION_SECRET=' "$ENV_FILE" || warn "$ENV_FILE 에 ADGEN_SESSION_SECRET 이 없습니다 — 계정이 있으면 기동이 거부됩니다."
+
+  # 추적 파일이 수정돼 있으면 중단합니다. "VM 에 뭐가 떠 있나"의 답이 SHA 로 성립하지 않게
+  # 되고, 뒤이어 부를 `merge --ff-only` 도 그 변경을 덮거나 실패합니다.
+  # (.env 처럼 ignore 된 파일은 애초에 여기 잡히지 않습니다.)
+  if ! git diff --quiet HEAD --; then
+    git --no-pager diff --stat HEAD -- >&2
+    die "추적 파일에 커밋되지 않은 변경이 있습니다. 배포 체크아웃은 origin 과 같아야 합니다."
+  fi
+
+  # 추적되지 않는 파일은 배포를 막지 않습니다 — 손으로 올려둔 스크립트나 덤프가 흔하고,
+  # 어느 커밋이 떠 있는지에는 영향을 주지 않습니다. 다만 보이게는 해 둡니다.
+  local untracked
+  untracked="$(git ls-files --others --exclude-standard | head -5)"
+  [[ -n "$untracked" ]] && warn "추적되지 않는 파일이 있습니다: $(tr '\n' ' ' <<<"$untracked")"
+
+  local free_gb
+  free_gb="$(df -BG --output=avail / 2>/dev/null | tail -1 | tr -dc '0-9' || true)"
+  if [[ -n "$free_gb" && "$free_gb" -lt "$DISK_WARN_GB" ]]; then
+    warn "디스크 여유 ${free_gb}GB. 재빌드 도중 실패할 수 있습니다 — 'docker image prune -f' 를 먼저 검토하세요."
+  fi
+
+  log "현재: $(git rev-parse --abbrev-ref HEAD) $(git rev-parse --short HEAD)"
+}
+
+# 체크아웃을 목표 ref 로 올립니다. 브랜치면 fast-forward 만 허용하고, 태그·커밋이면 분리 HEAD.
+update_checkout() {
+  log "origin 에서 가져오기"
+  git fetch origin --prune --tags
+
+  if git rev-parse --verify --quiet "origin/$REF" >/dev/null; then
+    git checkout "$REF"
+    # ⚠️ --ff-only. 배포 체크아웃에서 머지 커밋이 생기면 그 커밋은 어디에도 없는 코드가 되고,
+    #    "VM 에 뭐가 떠 있나"를 SHA 로 답할 수 없게 됩니다.
+    git merge --ff-only "origin/$REF"
+  else
+    git rev-parse --verify --quiet "$REF^{commit}" >/dev/null \
+      || die "ref 를 찾을 수 없습니다: $REF"
+    warn "origin/$REF 가 없어 분리 HEAD 로 체크아웃합니다 (롤백 용도로는 정상)."
+    git checkout --detach "$REF"
+  fi
+}
+
+show_changes() {
+  local prev="$1"
+  local now
+  now="$(git rev-parse HEAD)"
+
+  if [[ "$prev" == "$now" ]]; then
+    log "코드 변경 없음 ($(git rev-parse --short HEAD)) — 재빌드·재기동만 합니다."
+    return
+  fi
+
+  log "반영되는 커밋 ($(git rev-parse --short "$prev") -> $(git rev-parse --short "$now"))"
+  git --no-pager log --oneline "$prev..$now" | sed 's/^/    /'
+
+  # 계약·의존성·인프라가 바뀌었으면 확인할 것이 늘어납니다.
+  local touched
+  touched="$(git --no-pager diff --name-only "$prev..$now")"
+  grep -q '^packages/contracts/' <<<"$touched" && warn "계약(openapi.yaml)이 바뀌었습니다 — 프론트가 같은 판을 보고 있는지 확인하세요."
+  grep -q '^infra/\.env\.example$' <<<"$touched" && warn ".env.example 이 바뀌었습니다 — VM 의 infra/.env 에 새 키를 반영했는지 확인하세요."
+}
+
+bring_up() {
+  local build_args=()
+  [[ "$DO_BUILD" -eq 1 ]] && build_args+=(--build)
+
+  log "스택 교체 ($([[ "$DO_BUILD" -eq 1 ]] && echo "재빌드 포함" || echo "재빌드 없음"))"
+  # ⚠️ `-v` 가 없습니다. 그리고 넣지 마세요 — 계정·세션이 든 adgen-state 볼륨이 사라집니다.
+  # ⚠️ `--wait` 는 헬스체크가 healthy 가 될 때까지 기다리고, 안 되면 0이 아닌 값으로 끝납니다.
+  #    이것이 "배포됐는데 안 뜬 상태"를 성공으로 보고하지 않게 막는 유일한 장치입니다.
+  compose up -d "${build_args[@]}" --wait
+}
+
+http_code() {
+  curl -s -o /dev/null -m 10 -w '%{http_code}' "$1" 2>/dev/null || echo "000"
+}
+
+expect_code() {
+  local url="$1" want="$2" label="$3" got
+  got="$(http_code "$url")"
+  if [[ "$got" == "$want" ]]; then
+    echo "    OK   $label ($got)"
+  else
+    echo "    실패 $label (기대 $want, 실제 $got)"
+    return 1
+  fi
+}
+
+verify() {
+  log "관통 확인"
+  compose ps --format "table {{.Service}}\t{{.Status}}\t{{.Ports}}" | sed 's/^/    /'
+
+  # 상태 파일이 볼륨에 그대로 있는지. 여기서 없다고 나오면 볼륨이 갈렸다는 뜻입니다.
+  if compose exec -T backend test -f /data/adgen.sqlite; then
+    echo "    OK   상태 파일 /data/adgen.sqlite 보존"
+  else
+    warn "상태 파일이 없습니다 — 볼륨이 새로 만들어졌을 수 있습니다. 계정·세션을 확인하세요."
+  fi
+
+  # 계정이 실제로 몇 개 있는지. 0이면 로그인은 무조건 401 입니다(위 .env 함정의 최종 증상).
+  local accounts
+  accounts="$(compose exec -T backend python -c \
+    'import sqlite3;print(sqlite3.connect("/data/adgen.sqlite").execute("select count(*) from users").fetchone()[0])' \
+    2>/dev/null | tr -dc '0-9')"
+  if [[ "${accounts:-0}" -gt 0 ]]; then
+    echo "    OK   계정 ${accounts}건 시드됨"
+  else
+    warn "계정이 0건입니다 — infra/.env 의 ADGEN_ACCOUNTS 를 확인하세요."
+  fi
+
+  # 스텁인지 실물인지. 스텁의 출력은 측정값이 아닙니다(AGENTS.md '현재 상태').
+  local mode
+  mode="$(compose exec -T ai-engine printenv ADGEN_GENERATION_MODE 2>/dev/null | tr -d '\r\n')"
+  echo "    INFO 생성 모드: ${mode:-미설정}"
+
+  if ! command -v curl >/dev/null 2>&1; then
+    warn "curl 이 없어 HTTP 확인을 건너뜁니다."
+    return 0
+  fi
+
+  local ok=0
+  expect_code "http://127.0.0.1:${BACKEND_PORT}/health" 200 "backend /health" || ok=1
+  expect_code "http://127.0.0.1:${FRONTEND_PORT}/" 200 "frontend /" || ok=1
+  # 프론트(80)를 거쳐 backend 로 넘어가는 프록시 경로까지 한 번에 봅니다. 401 이 정답입니다 —
+  # 라우팅·인증·에러 계약이 셋 다 살아 있어야 이 코드가 나옵니다.
+  expect_code "http://127.0.0.1:${FRONTEND_PORT}/v1/sessions" 401 "프록시 /v1/sessions (미인증)" || ok=1
+  return "$ok"
+}
+
+on_failure() {
+  local prev="$1"
+  echo >&2
+  warn "배포 실패. 최근 로그 40줄:"
+  compose logs --tail 40 2>&1 | sed 's/^/    /' >&2 || true
+  echo >&2
+  warn "직전 상태로 되돌리려면:"
+  echo "    git -C \"$ROOT\" checkout --detach $prev && bash \"$ROOT/scripts/deploy-vm.sh\" --ref $prev" >&2
+}
+
+main() {
+  parse_args "$@"
+  cd "$ROOT"
+
+  preflight
+
+  if [[ "$MODE" == "check" ]]; then
+    log "점검 모드 — 아무것도 바꾸지 않습니다."
+    verify || warn "확인 항목 일부가 실패했습니다."
+    return 0
+  fi
+
+  local prev_sha
+  prev_sha="$(git rev-parse HEAD)"
+  trap 'on_failure "$prev_sha"' ERR
+
+  update_checkout
+  show_changes "$prev_sha"
+  bring_up
+
+  if [[ "$DO_VERIFY" -eq 1 ]]; then
+    verify
+  fi
+
+  trap - ERR
+  log "완료: $(git rev-parse --abbrev-ref HEAD) $(git rev-parse --short HEAD)"
+  echo "    롤백이 필요하면: bash scripts/deploy-vm.sh --ref $(git rev-parse --short "$prev_sha")"
+
+  # ⚠️ 브라우저 로그인은 HTTPS 종단이 붙기 전까지 성립하지 않습니다 — 세션 쿠키가 `Secure`
+  #    고정인데(apps/backend/src/api/routes/auth.py) 평문 HTTP 응답의 쿠키는 브라우저가
+  #    저장하지 않습니다. 이 배포의 검증 수단은 curl 입니다 (API_계약.md 8.3절).
+  echo "    참고: HTTPS 종단 전까지 브라우저 로그인은 성립하지 않습니다 (curl 검증용)."
+}
+
+main "$@"

--- a/scripts/deploy-vm.sh
+++ b/scripts/deploy-vm.sh
@@ -17,8 +17,11 @@
 # 사용: bash scripts/deploy-vm.sh                 origin/main 으로 배포 (재빌드 포함)
 #       bash scripts/deploy-vm.sh --ref <ref>     다른 브랜치·태그·커밋으로 배포
 #       bash scripts/deploy-vm.sh --check         점검만 (fetch·빌드·기동 없음)
-#       bash scripts/deploy-vm.sh --no-build      코드 갱신 없이 재기동만 (.env 변경 반영 등)
+#       bash scripts/deploy-vm.sh --no-build      체크아웃·이미지 그대로 재기동 (.env 변경 반영)
 #       bash scripts/deploy-vm.sh --skip-verify   배포 후 관통 확인 생략
+#
+# ⚠️ --no-build 는 체크아웃을 갱신하지 않습니다(--ref 와 함께 쓸 수 없습니다). 코드를 옮기면서
+#    이미지를 그대로 두면 도는 코드와 `git rev-parse HEAD` 가 어긋납니다.
 # ⚠️ -E(errtrace) 가 있어야 ERR 트랩이 함수 안까지 따라갑니다. 없으면 실패한 배포가 로그도
 #    롤백 안내도 없이 조용히 끝납니다 — 이 스크립트의 실패 처리는 전부 함수 안에서 납니다.
 set -Eeuo pipefail
@@ -40,6 +43,7 @@ BACKEND_PORT="${ADCRAFT_BACKEND_PORT:-8000}"
 DISK_WARN_GB=10
 
 REF="main"
+REF_GIVEN=0
 MODE="deploy"
 DO_BUILD=1
 DO_VERIFY=1
@@ -49,16 +53,25 @@ warn() { echo "  ! $*" >&2; }
 die()  { echo "[중단] $*" >&2; exit 1; }
 
 parse_args() {
+  local arg
   while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --ref)         REF="${2:?--ref 뒤에 브랜치·태그·커밋이 필요합니다}"; shift 2 ;;
+    arg="$1"
+    case "$arg" in
+      --ref)         REF="${2:?--ref 뒤에 브랜치·태그·커밋이 필요합니다}"; REF_GIVEN=1; shift 2 ;;
       --check)       MODE="check"; shift ;;
       --no-build)    DO_BUILD=0; shift ;;
       --skip-verify) DO_VERIFY=0; shift ;;
-      -h|--help)     sed -n '1,25p' "$0"; exit 0 ;;
-      *)             die "모르는 인자: $1 (사용법은 --help)" ;;
+      -h|--help)     sed -n '1,27p' "$0"; exit 0 ;;
+      *)             die "모르는 인자: $arg (사용법은 --help)" ;;
     esac
   done
+
+  # ⚠️ 둘을 같이 받으면 "체크아웃은 옮기고 이미지는 그대로"가 되어, 체크아웃의 커밋 SHA 가
+  #    실제로 도는 코드를 가리키지 않게 됩니다. --ff-only 로 지키려는 성질이 바로 그것이라
+  #    조합 자체를 거부합니다 (PR #117 리뷰, Eastar0102).
+  if [[ "$DO_BUILD" -eq 0 && "$REF_GIVEN" -eq 1 ]]; then
+    die "--no-build 와 --ref 는 같이 쓸 수 없습니다. 코드를 옮기려면 재빌드가 필요합니다."
+  fi
 }
 
 compose() {
@@ -153,7 +166,8 @@ bring_up() {
 }
 
 http_code() {
-  curl -s -o /dev/null -m 10 -w '%{http_code}' "$1" 2>/dev/null || echo "000"
+  local url="$1"
+  curl -s -o /dev/null -m 10 -w '%{http_code}' "$url" 2>/dev/null || echo "000"
 }
 
 expect_code() {
@@ -234,8 +248,16 @@ main() {
   prev_sha="$(git rev-parse HEAD)"
   trap 'on_failure "$prev_sha"' ERR
 
-  update_checkout
-  show_changes "$prev_sha"
+  # ⚠️ --no-build 은 체크아웃을 건드리지 않습니다. 갱신만 하고 이미지를 그대로 두면 도는 코드는
+  #    옛것인데 `git rev-parse HEAD` 는 새 커밋을 답해, "VM 에 뭐가 떠 있나"가 조용히 거짓이
+  #    됩니다. 코드를 옮기는 경로는 재빌드하는 쪽 하나뿐입니다 (PR #117 리뷰, Eastar0102).
+  if [[ "$DO_BUILD" -eq 1 ]]; then
+    update_checkout
+    show_changes "$prev_sha"
+  else
+    log "체크아웃 유지 ($(git rev-parse --short HEAD)) — 설정만 다시 읽어 재기동합니다."
+  fi
+
   bring_up
 
   if [[ "$DO_VERIFY" -eq 1 ]]; then


### PR DESCRIPTION
## 📌 변경 개요

배포 절차를 `scripts/deploy-vm.sh` 하나로 고정하고, `infra/README.md`에 비어 있던 자리
("배포는 SSH 접속 후 `git pull` + `docker compose up` 수동 경로입니다. **절차를 이 문서에 남기세요**")를 채웁니다.

SA 키 발급이 조직 정책으로 막혀 배포는 SSH 수동 경로뿐입니다([ADR-0011](docs/adr/0011-배포_환경_스펙과_권한_경계.md)).
그 절차가 사람의 기억에만 있어서 08-15 와 08-18 두 번의 배포에서 확인 항목이 매번 달랐습니다.

```bash
ssh "$ADCRAFT_VM" 'cd ~/adcraft && bash scripts/deploy-vm.sh'
```

| 명령 | 하는 일 |
|---|---|
| `deploy-vm.sh` | `origin/main` fast-forward -> 재빌드 -> 스택 교체 -> 관통 확인 |
| `--ref <ref>` | 다른 브랜치·태그·커밋으로. 롤백도 이 경로 |
| `--check` | 점검만. 아무것도 바꾸지 않음 |
| `--no-build` | 재빌드 없이 재기동 (`.env`만 고쳤을 때) |

스크립트가 사람 대신 지키는 것 넷:

- **`infra/.env` 없이 기동하지 않습니다.** 없으면 `ADGEN_ACCOUNTS`가 빈 문자열로 넘어가는데 `seed([])`는 아무것도 지우지 않아 **기동은 성공한 채 로그인만 어긋납니다.** 배포 실패로 보이지 않는 것이 이 함정의 전부입니다 (`test_startup.py`의 회귀 시나리오).
- **볼륨을 건드리는 플래그를 쓰지 않습니다** (`-v` 로 계정과 세션이 사라짐, ADR-0014).
- **`git merge --ff-only`만 씁니다.** 배포 체크아웃에 머지 커밋이 생기면 "VM 에 뭐가 떠 있나"를 커밋 SHA 로 답할 수 없습니다.
- **`--wait`로 healthy 를 확인**하고, 실패하면 로그와 롤백 명령을 출력합니다.

---

## 🔗 관련 이슈

- Closes #

---

## 📋 변경 유형

- [x] 🔧 설정 / 환경
- [x] 📝 문서 / 주석

---

## 🧪 테스트 / 검증 방법

**실제 배포 VM 에서 실행해 확인했습니다** (스크립트를 임시로 올려 실행 -> 확인 후 제거).

1. `--check` 모드 - 확인 항목 전량 통과

```
==> 관통 확인
    OK   상태 파일 /data/adgen.sqlite 보존
    OK   계정 2건 시드됨
    INFO 생성 모드: stub
    OK   backend /health (200)
    OK   frontend / (200)
    OK   프록시 /v1/sessions (미인증) (401)
```

2. `--no-build` 실전 경로 - fetch -> ff -> `up -d --wait` -> 세 컨테이너 healthy -> 확인 항목 통과 -> 롤백 명령 출력까지 확인
3. 실패 경로 - 없는 `--ref` 로 실행 시 `[중단] ref 를 찾을 수 없습니다` 로 종료(exit 1), compose 로그 노이즈 없음
4. ERR 트랩이 함수 안에서 실제로 발화하는지 별도 하네스로 확인
5. `bash -n` 문법 검사, 앱 테스트 2종 (backend 289 + ai-engine 137, 전부 통과)

---

## ⚠️ 리뷰어 주의사항

- **접속 정보(외부 IP · 프로젝트 ID · 인스턴스명)를 스크립트에도 README 에도 넣지 않았습니다.** 저장소가 public 이기 때문이며, 접속 경로의 정본은 `GCP_VM_사용_가이드.md` 입니다. 리뷰에서 "편의를 위해 호스트를 적어두자"는 제안은 받지 말아 주세요.
- **스크립트 자체의 함정 둘**을 주석으로 남겼습니다. 리팩터링할 때 깨지기 쉬운 지점입니다:
  - 전체를 `main()` 으로 감싸고 마지막 줄에서 호출합니다. 이 스크립트는 **자기 자신이 든 체크아웃을 갱신**하므로, 평범하게 위에서 아래로 쓰면 실행 도중 `git merge` 가 파일을 바꿔 bash 가 엉뚱한 오프셋을 읽습니다.
  - `set -Eeuo pipefail` 의 **`-E` 가 필요합니다.** 없으면 ERR 트랩이 함수 안까지 따라가지 않아 실패한 배포가 로그도 롤백 안내도 없이 끝납니다.
- 포트(80 / 8000)는 `ADCRAFT_FRONTEND_PORT` · `ADCRAFT_BACKEND_PORT` 로 덮을 수 있게 두었지만 **정본은 compose 입니다.** 값이 갈리면 compose 쪽을 고쳐야 합니다.

---

## 💬 기타

- **HTTPS 종단은 이 PR 범위가 아닙니다.** 세션 쿠키가 `Secure` 고정이라 브라우저 로그인은 여전히 성립하지 않으며, 스크립트의 확인 항목도 `curl` 전제로 짜여 있습니다 (API_계약 8.3절). 그 사실을 README 와 스크립트 출력에 명시해 두었습니다.
- 로컬 `pre-push` 훅이 conda `ai` 환경(fastapi 0.115.9)을 가리켜 이 브랜치와 무관한 지점에서 실패합니다. 레포 `.venv`(fastapi 0.141.1)로는 426건 전부 통과하며, 훅 인터프리터 문제는 별건으로 다루는 편이 낫겠습니다.
