### PR TITLE
feat(eval): 골든셋을 draft:generate에 태우는 수집 하네스를 놓습니다

### DIFF
--- a/apps/ai-engine/eval/README.md
+++ b/apps/ai-engine/eval/README.md
@@ -35,10 +35,16 @@ python eval/run_collect_ad_copy.py --yes       # 수집 실행 (스텁이면 요
 
 **2026-08-24에 수집이 다섯 지표 중 하나(가드레일 위반 건수)만 생겼습니다.**
 `run_collect_ad_copy.py`가 `ad_copy.jsonl` 26건을 `draft:generate`에 태워 on/off 팔
-회차를 만들고, `run_metrics.py --input`이 바로 읽습니다. **스텁 모드에서는 comic
-16건이 전부 스킵됩니다**(구현_범위 1절, 스텁이 만화형을 안 채움) - 로컬에서 스텁으로
-직접 확인함(2026-08-24, single_ad 10건 x 2팔 = 20건 채점 가능, 표본 20/위반 0로
-`run_metrics.py`까지 정상 연결 확인. comic 포함 실측은 실물 모드가 있어야 합니다).
+회차를 만듭니다. **on과 off는 서로 다른 파일에 나뉘어 기록됩니다**(`..._on.jsonl` /
+`..._off.jsonl`) - 같은 파일에 합치면 `run_metrics.py`가 팔을 모르고 `guardrailPassed`를
+전부 합산해 대조군(off)의 위반이 배포 설정(on)의 위반으로 보고됩니다. 두 파일을
+`run_metrics.py --input`으로 각각 채점하세요. **스텁 모드에서는 comic 16건이 전부
+스킵됩니다**(구현_범위 1절, 스텁이 만화형을 안 채움). **스텁의 on 팔은 애초에
+`check_claims`를 부르지 않으므로**(`_generate_stub`이 검사 없이 응답만 돌려줌)
+`guardrailPassed` 필드 자체가 비어 있어 채점 대상에서 빠집니다 - 로컬에서 스텁으로
+직접 확인함(2026-08-24, single_ad 10건: on 팔은 측정 안 함으로 정상 표시, off 팔만
+표본 10/위반 0로 `run_metrics.py`까지 정상 연결 확인. comic 포함 실측은 실물 모드가
+있어야 합니다).
 나머지 넷이 왜 비어 있는지는 `--describe`가 함께 출력합니다 — 특히
 **브랜드 스타일 일치도는 막혀 있습니다**(브랜드 레퍼런스셋이 없습니다).
 

--- a/apps/ai-engine/eval/README.md
+++ b/apps/ai-engine/eval/README.md
@@ -15,6 +15,7 @@
 | `test_metrics.py` | 지표 함수 자체의 단위 테스트 (CI에서 실행됨) |
 | `golden_dataset/*.jsonl` | 채점 기준 데이터. 변경 시 이유를 커밋 메시지에 남길 것 |
 | `run_guardrail_detector.py` | 검출기 단위 시험 — 위반 예문을 `check_claims`에 직접 통과 (모델 호출 없음, 요금 0) |
+| `run_collect_ad_copy.py` | 수집 — 골든셋(`ad_copy.jsonl`)을 실제로 `draft:generate`에 태워 가드레일 on/off 회차 기록을 만듦 |
 | `run_metrics.py` | 지표 채점 — 수집된 회차 기록(JSONL)을 읽어 지표 표를 채웁니다 |
 
 ## 수집과 채점을 파일로 가릅니다
@@ -27,10 +28,19 @@
 ```bash
 python eval/run_metrics.py --describe          # 기록 스키마. 입력 불필요
 python eval/run_metrics.py --input runs/x.jsonl
+
+python eval/run_collect_ad_copy.py --dry-run   # 수집 계획만 (호출 없음)
+python eval/run_collect_ad_copy.py --yes       # 수집 실행 (스텁이면 요금 0)
 ```
 
-**2026-08-22 기준 수집은 아직 없습니다.** 무엇이 왜 비어 있는지는 `--describe`가 함께
-출력합니다 — 특히 **브랜드 스타일 일치도는 막혀 있습니다**(브랜드 레퍼런스셋이 없습니다).
+**2026-08-24에 수집이 다섯 지표 중 하나(가드레일 위반 건수)만 생겼습니다.**
+`run_collect_ad_copy.py`가 `ad_copy.jsonl` 26건을 `draft:generate`에 태워 on/off 팔
+회차를 만들고, `run_metrics.py --input`이 바로 읽습니다. **스텁 모드에서는 comic
+16건이 전부 스킵됩니다**(구현_범위 1절, 스텁이 만화형을 안 채움) - 로컬에서 스텁으로
+직접 확인함(2026-08-24, single_ad 10건 x 2팔 = 20건 채점 가능, 표본 20/위반 0로
+`run_metrics.py`까지 정상 연결 확인. comic 포함 실측은 실물 모드가 있어야 합니다).
+나머지 넷이 왜 비어 있는지는 `--describe`가 함께 출력합니다 — 특히
+**브랜드 스타일 일치도는 막혀 있습니다**(브랜드 레퍼런스셋이 없습니다).
 
 ⚠️ **데이터가 없는 지표는 0이 아니라 "측정 안 함"으로 냅니다.** 0은 "쟀는데 0이었다"로 읽히고,
 목표치와 나란히 놓이면 미달로 읽힙니다. 재지 않은 것과 재서 나쁜 것은 다릅니다.
@@ -59,11 +69,11 @@ python eval/run_metrics.py --input runs/x.jsonl
 ```
 
 `request`는 **`ai_engine.models.generation.DraftGenerateRequest`의 와이어 형태와 그대로
-일치**하도록 만들었습니다 (`guardrailApplied`만 제외 - 아래 참고). **`draft:generate`를 실제로
-호출해 카피를 만드는 수집 스크립트는 아직 없습니다** - 생기면
-`DraftGenerateRequest.model_validate(case["request"])`로 바로 넣을 수 있어야 하고, 그 계약이
-깨지면(필드 추가·이름 변경) 이 파일도 같은 PR에서 함께 고쳐야 합니다. 수집된 출력은
-`run_metrics.py --input`이 읽는 JSONL로 쌓이고, 그 뒤 `claim_support_rate` 등으로 채점됩니다.
+일치**하도록 만들었습니다 (`guardrailApplied`만 제외 - 아래 참고), 그래서
+`DraftGenerateRequest.model_validate(case["request"])`로 바로 넣을 수 있습니다 -
+`run_collect_ad_copy.py`가 실제로 이렇게 씁니다. 이 계약이 깨지면(필드 추가·이름 변경)
+이 파일과 그 스크립트를 같은 PR에서 함께 고쳐야 합니다. 수집된 출력은 `run_metrics.py
+--input`이 읽는 JSONL로 쌓이고, 그 뒤 `claim_support_rate` 등으로 채점됩니다.
 
 **`golden_dataset/guardrail_claims.jsonl`(검출기 단위 시험, `run_guardrail_detector.py`)과는
 다른 파일이자 다른 지점을 잽니다.** `guardrail_claims.jsonl`은 사람이 미리 써 둔

--- a/apps/ai-engine/eval/run_collect_ad_copy.py
+++ b/apps/ai-engine/eval/run_collect_ad_copy.py
@@ -1,0 +1,190 @@
+"""수집 하네스 - 골든셋(golden_dataset/ad_copy.jsonl)의 각 케이스를 실제로
+`draft:generate`에 태워 가드레일 on/off 대조 회차 기록(JSONL)을 만듭니다
+(생성_파이프라인 5.1절, D2). `run_metrics.py`가 읽는 "가드레일 위반 건수" 한 줄만
+채웁니다 - 그 이상은 이 스크립트의 몫이 아닙니다(아래 "채우지 않는 것" 참고).
+
+**요금이 나갈 수 있습니다.** `ADGEN_GENERATION_MODE=model`이고 `ADGEN_MODEL_API_KEY`가
+있으면 텍스트 모델(`text_model`, 기본 `gpt-5`)을 케이스당 최대 2회(on/off 팔) x 최대
+2회(1차 + 위반 시 재생성)까지 호출합니다. **이미지 생성 API는 부르지 않습니다** -
+`draft:generate`는 텍스트(카피/대사)만 만들고, 이미지는 `render`가 별도로 맡습니다.
+
+⚠️ **스텁 모드(기본값)에서는 comic 케이스가 전부 스킵됩니다.** `_generate_stub`이
+만화형을 안 채우기 때문입니다(구현_범위 1절, "the stub is comic-blind" - 여섯 칸을
+지어내면 만화 경로가 완성된 것처럼 보여서 일부러 비워 둔 자리입니다). 즉 스텁으로는
+이 골든셋 26건 중 comic 16건을 검증할 수 없고, 실행해보려면 실물 모드가 필요합니다.
+
+    python eval/run_collect_ad_copy.py --dry-run             # 호출 없이 계획만 출력
+    python eval/run_collect_ad_copy.py --yes                 # 실행 (스텁이면 요금 0)
+    ADGEN_GENERATION_MODE=model ADGEN_MODEL_API_KEY=sk-... \\
+        python eval/run_collect_ad_copy.py --yes --limit 2   # 실물 2건만 먼저 확인
+
+채우지 않는 것:
+  - **카피 사실 일치율** - 주장 단위 채점에 별도 채점 모델이 필요합니다(채점 모델 !=
+    생성 모델). PR #217이 의도적으로 범위 밖에 둔 것과 같은 이유로 여기서도 안 만듭니다.
+  - **생성 지연** - `draft:generate`는 이미지를 안 거치므로 "잡 접수 -> 결과 이미지
+    완료"라는 지표 정의와 다른 것을 재게 됩니다. 그 지표는 기동된 서비스에 HTTP로
+    재야 합니다(앱 간 import 금지, run_metrics.py의 같은 경고).
+  - **열화 발생률(messageMode)** - `brief:fill`/세션 단위 개념이라 `draft:generate`만
+    부르는 이 스크립트에서는 관측되지 않습니다.
+
+⚠️ 파일 이름이 `run_`인 것은 규약입니다. `eval/`은 pytest 수집 대상이라 `test_`로
+지으면 CI가 이것을 테스트로 집어 외부 API를 호출합니다 (eval/README.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any, Literal
+
+from ai_engine import draft, guardrail, render_prompt
+from ai_engine.config import Settings
+from ai_engine.models import DraftGenerateRequest
+
+DEFAULT_INPUT = Path(__file__).parent / "golden_dataset" / "ad_copy.jsonl"
+Arm = Literal["on", "off"]
+
+
+def load_cases(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path}:{line_no} 를 읽지 못했습니다: {exc}") from exc
+    return rows
+
+
+def build_request(case: dict[str, Any], *, guardrail_applied: bool) -> DraftGenerateRequest:
+    payload = dict(case["request"])
+    payload["guardrailApplied"] = guardrail_applied
+    return DraftGenerateRequest.model_validate(payload)
+
+
+def run_one(case: dict[str, Any], arm: Arm, settings: Settings, run_id: str) -> dict[str, Any]:
+    """한 케이스, 한 팔. `guardrailPassed`가 채워지지 않으면 그 회차는 위반 건수
+    분모에서 빠집니다(run_metrics.py가 필드 없음과 실측값을 구분하므로 의도된 동작)."""
+    request = build_request(case, guardrail_applied=(arm == "on"))
+    record: dict[str, Any] = {
+        "runId": run_id,
+        "caseId": case["id"],
+        "caseType": case["caseType"],
+        "guardrailFocus": case["guardrailFocus"],
+        "outputType": request.output_type,
+        "arm": arm,
+    }
+    try:
+        response = draft.generate_draft(request, settings)
+    except NotImplementedError as exc:
+        # 스텁 + comic. 구현_범위 1절이 의도한 결손이지 이 스크립트의 버그가 아닙니다.
+        record["skipped"] = str(exc)
+        return record
+    except draft.DraftFailedError as exc:
+        record["error"] = str(exc)
+        return record
+
+    record["guardrailApplied"] = response.guardrail_applied
+    if response.refusal_reason is not None:
+        record["refusalReason"] = response.refusal_reason
+        if response.refusal_reason == "guardrail":
+            # on 팔에서만 나옵니다 - off 팔은 check_claims를 아예 안 부르므로 이
+            # 사유가 나올 수 없습니다(_guarded_attempts).
+            record["guardrailPassed"] = False
+        # "no_evidence"는 가드레일 위반이 아니라 "쓸 근거가 없어 거절"이라
+        # guardrailPassed를 채우지 않고 사유만 남깁니다.
+        return record
+
+    assert response.draft is not None
+    texts = render_prompt.dialogue_of(response.draft)
+    if arm == "on":
+        # generate_draft가 이미 검사(+ 위반 시 1회 재생성 후 재검사)까지 끝낸
+        # 결과이므로, 시안이 돌아왔다는 것 자체가 최종 통과입니다. 여기서 다시
+        # 검사하면 재생성으로 이미 지운 1차 위반까지 통과로 잡혀 on/off 대조가
+        # 대칭이 아니게 됩니다.
+        record["guardrailPassed"] = True
+    else:
+        # off 팔은 guardrail_applied=False라 generate_draft가 check_claims를
+        # 아예 안 부릅니다. 원본 응답에는 위반 여부가 실려 있지 않으므로 하네스가
+        # 사후에 직접 돌려야 합니다 - RECORD_SCHEMA의 경고와 같은 이유입니다.
+        # 근거 문자열은 draft._evidence를 그대로 재사용합니다: sellingPoint + note
+        # + productName 세 필드를 합치는 규칙이 2026-08-20에 한 번 바뀐 적이 있고
+        # (생성_파이프라인 5.2절), 여기서 다시 적으면 그 드리프트가 반복됩니다.
+        evidence = draft._evidence(request.brief)  # noqa: SLF001 - 의도적 재사용, 위 주석 참고
+        report = guardrail.check_claims(texts, evidence)
+        record["guardrailPassed"] = report.passed
+        if report.violations:
+            record["violationKinds"] = sorted({kind for kind, _ in report.violations})
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument(
+        "--out", type=Path, default=None, help="회차 기록 출력 경로 (기본: runs/ad_copy_<run_id>.jsonl)"
+    )
+    parser.add_argument("--limit", type=int, default=None, help="앞에서부터 N건만 (시험 실행용)")
+    parser.add_argument("--case", action="append", default=None, help="특정 id만 실행 (반복 가능)")
+    parser.add_argument("--dry-run", action="store_true", help="호출 없이 실행 계획만 출력")
+    parser.add_argument(
+        "--yes", action="store_true", help="실제로 호출합니다 (model 모드면 요금이 나갑니다)"
+    )
+    args = parser.parse_args()
+
+    settings = Settings()
+    cases = load_cases(args.input)
+    if args.case:
+        wanted = set(args.case)
+        cases = [c for c in cases if c["id"] in wanted]
+        missing = wanted - {c["id"] for c in cases}
+        if missing:
+            parser.error(f"--case로 지정한 id를 골든셋에서 못 찾았습니다: {sorted(missing)}")
+    if args.limit is not None:
+        cases = cases[: args.limit]
+    if not cases:
+        parser.error("실행할 케이스가 없습니다 (--input/--case/--limit 확인)")
+
+    comic_n = sum(1 for c in cases if c["request"]["outputType"] == "comic")
+    print(f"{len(cases)}건 x 2팔(on/off) = {len(cases) * 2}회 호출 예정 (mode={settings.generation_mode})")
+    if settings.generation_mode == "stub" and comic_n:
+        print(f"주의: 스텁 모드라 comic {comic_n}건은 팔마다 스킵됩니다(구현_범위 1절, 만화 미지원).")
+    if settings.generation_mode == "model" and not settings.model_api_key:
+        print("주의: model 모드인데 ADGEN_MODEL_API_KEY가 비어 있어 모든 호출이 실패로 기록됩니다.")
+
+    if args.dry_run:
+        for c in cases:
+            print(f"  {c['id']:8} {c['caseType']:11} {c['guardrailFocus']:22} {c['request']['outputType']}")
+        return 0
+    if not args.yes:
+        parser.error("--yes 없이는 실행하지 않습니다 (model 모드면 요금이 나갑니다). 계획만 보려면 --dry-run.")
+
+    run_id = time.strftime("%Y%m%d-%H%M%S")
+    out_path = args.out or Path(__file__).parent / "runs" / f"ad_copy_{run_id}.jsonl"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    records: list[dict[str, Any]] = []
+    with out_path.open("w", encoding="utf-8") as f:
+        for i, case in enumerate(cases, 1):
+            for arm in ("on", "off"):
+                record = run_one(case, arm, settings, run_id)
+                records.append(record)
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+                f.flush()  # 회차 중간에 죽어도 그때까지 기록은 남습니다
+            print(f"[{i}/{len(cases)}] {case['id']} 완료")
+
+    skipped = sum(1 for r in records if "skipped" in r)
+    errored = sum(1 for r in records if "error" in r)
+    graded = sum(1 for r in records if "guardrailPassed" in r)
+    print(f"\n{out_path} 에 {len(records)}줄 기록. 스킵 {skipped}건, 실패 {errored}건, 채점 가능 {graded}건")
+    print(f"다음: python eval/run_metrics.py --input {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/ai-engine/eval/run_collect_ad_copy.py
+++ b/apps/ai-engine/eval/run_collect_ad_copy.py
@@ -113,7 +113,7 @@ def run_one(case: dict[str, Any], arm: Arm, settings: Settings, run_id: str) -> 
         # 근거 문자열은 draft._evidence를 그대로 재사용합니다: sellingPoint + note
         # + productName 세 필드를 합치는 규칙이 2026-08-20에 한 번 바뀐 적이 있고
         # (생성_파이프라인 5.2절), 여기서 다시 적으면 그 드리프트가 반복됩니다.
-        evidence = draft._evidence(request.brief)  # noqa: SLF001 - 의도적 재사용, 위 주석 참고
+        evidence = draft._evidence(request.brief)
         report = guardrail.check_claims(texts, evidence)
         record["guardrailPassed"] = report.passed
         if report.violations:
@@ -127,7 +127,10 @@ def main() -> int:
     )
     parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
     parser.add_argument(
-        "--out", type=Path, default=None, help="회차 기록 출력 경로 (기본: runs/ad_copy_<run_id>.jsonl)"
+        "--out",
+        type=Path,
+        default=None,
+        help="회차 기록 출력 경로 (기본: runs/ad_copy_<run_id>.jsonl)",
     )
     parser.add_argument("--limit", type=int, default=None, help="앞에서부터 N건만 (시험 실행용)")
     parser.add_argument("--case", action="append", default=None, help="특정 id만 실행 (반복 가능)")
@@ -151,18 +154,26 @@ def main() -> int:
         parser.error("실행할 케이스가 없습니다 (--input/--case/--limit 확인)")
 
     comic_n = sum(1 for c in cases if c["request"]["outputType"] == "comic")
-    print(f"{len(cases)}건 x 2팔(on/off) = {len(cases) * 2}회 호출 예정 (mode={settings.generation_mode})")
+    print(
+        f"{len(cases)}건 x 2팔(on/off) = {len(cases) * 2}회 호출 예정 (mode={settings.generation_mode})"
+    )
     if settings.generation_mode == "stub" and comic_n:
-        print(f"주의: 스텁 모드라 comic {comic_n}건은 팔마다 스킵됩니다(구현_범위 1절, 만화 미지원).")
+        print(
+            f"주의: 스텁 모드라 comic {comic_n}건은 팔마다 스킵됩니다(구현_범위 1절, 만화 미지원)."
+        )
     if settings.generation_mode == "model" and not settings.model_api_key:
         print("주의: model 모드인데 ADGEN_MODEL_API_KEY가 비어 있어 모든 호출이 실패로 기록됩니다.")
 
     if args.dry_run:
         for c in cases:
-            print(f"  {c['id']:8} {c['caseType']:11} {c['guardrailFocus']:22} {c['request']['outputType']}")
+            print(
+                f"  {c['id']:8} {c['caseType']:11} {c['guardrailFocus']:22} {c['request']['outputType']}"
+            )
         return 0
     if not args.yes:
-        parser.error("--yes 없이는 실행하지 않습니다 (model 모드면 요금이 나갑니다). 계획만 보려면 --dry-run.")
+        parser.error(
+            "--yes 없이는 실행하지 않습니다 (model 모드면 요금이 나갑니다). 계획만 보려면 --dry-run."
+        )
 
     run_id = time.strftime("%Y%m%d-%H%M%S")
     out_path = args.out or Path(__file__).parent / "runs" / f"ad_copy_{run_id}.jsonl"
@@ -181,7 +192,9 @@ def main() -> int:
     skipped = sum(1 for r in records if "skipped" in r)
     errored = sum(1 for r in records if "error" in r)
     graded = sum(1 for r in records if "guardrailPassed" in r)
-    print(f"\n{out_path} 에 {len(records)}줄 기록. 스킵 {skipped}건, 실패 {errored}건, 채점 가능 {graded}건")
+    print(
+        f"\n{out_path} 에 {len(records)}줄 기록. 스킵 {skipped}건, 실패 {errored}건, 채점 가능 {graded}건"
+    )
     print(f"다음: python eval/run_metrics.py --input {out_path}")
     return 0
 

--- a/apps/ai-engine/eval/run_collect_ad_copy.py
+++ b/apps/ai-engine/eval/run_collect_ad_copy.py
@@ -3,6 +3,11 @@
 (생성_파이프라인 5.1절, D2). `run_metrics.py`가 읽는 "가드레일 위반 건수" 한 줄만
 채웁니다 - 그 이상은 이 스크립트의 몫이 아닙니다(아래 "채우지 않는 것" 참고).
 
+⚠️ **on과 off는 서로 다른 파일에 기록됩니다** (`<out>_on.jsonl` / `<out>_off.jsonl`).
+같은 파일에 이어 쓰면 `run_metrics.py`가 arm을 모르고 `guardrailPassed`를 전부 합산해,
+대조군(off)의 위반이 배포 설정(on)의 위반 건수로 보고됩니다. 두 파일을 각각
+`run_metrics.py --input`에 넣으세요.
+
 **요금이 나갈 수 있습니다.** `ADGEN_GENERATION_MODE=model`이고 `ADGEN_MODEL_API_KEY`가
 있으면 텍스트 모델(`text_model`, 기본 `gpt-5`)을 케이스당 최대 2회(on/off 팔) x 최대
 2회(1차 + 위반 시 재생성)까지 호출합니다. **이미지 생성 API는 부르지 않습니다** -
@@ -39,6 +44,8 @@ import time
 from pathlib import Path
 from typing import Any, Literal
 
+from pydantic import ValidationError
+
 from ai_engine import draft, guardrail, render_prompt
 from ai_engine.config import Settings
 from ai_engine.models import DraftGenerateRequest
@@ -71,6 +78,7 @@ def run_one(case: dict[str, Any], arm: Arm, settings: Settings, run_id: str) -> 
     request = build_request(case, guardrail_applied=(arm == "on"))
     record: dict[str, Any] = {
         "runId": run_id,
+        "mode": settings.generation_mode,  # 스텁 회차를 실측으로 읽지 않기 위해
         "caseId": case["id"],
         "caseType": case["caseType"],
         "guardrailFocus": case["guardrailFocus"],
@@ -101,11 +109,19 @@ def run_one(case: dict[str, Any], arm: Arm, settings: Settings, run_id: str) -> 
     assert response.draft is not None
     texts = render_prompt.dialogue_of(response.draft)
     if arm == "on":
-        # generate_draft가 이미 검사(+ 위반 시 1회 재생성 후 재검사)까지 끝낸
-        # 결과이므로, 시안이 돌아왔다는 것 자체가 최종 통과입니다. 여기서 다시
-        # 검사하면 재생성으로 이미 지운 1차 위반까지 통과로 잡혀 on/off 대조가
-        # 대칭이 아니게 됩니다.
-        record["guardrailPassed"] = True
+        if settings.generation_mode == "stub":
+            # _generate_stub는 check_claims를 아예 부르지 않습니다(guardrail_applied를
+            # 그대로 돌려줄 뿐). "응답이 왔다"를 "통과"로 적으면 검사하지 않은 것을
+            # 통과로 기록하게 됩니다 - off 팔에 대한 RECORD_SCHEMA의 경고와 같은
+            # 문제가 스텁 on 팔에서 그대로 생깁니다. 필드를 비워 두면 run_metrics.py가
+            # 분모에서 뺍니다.
+            pass
+        else:
+            # generate_draft가 이미 검사(+ 위반 시 1회 재생성 후 재검사)까지 끝낸
+            # 결과이므로, 시안이 돌아왔다는 것 자체가 최종 통과입니다. 여기서 다시
+            # 검사하면 재생성으로 이미 지운 1차 위반까지 통과로 잡혀 on/off 대조가
+            # 대칭이 아니게 됩니다.
+            record["guardrailPassed"] = True
     else:
         # off 팔은 guardrail_applied=False라 generate_draft가 check_claims를
         # 아예 안 부릅니다. 원본 응답에는 위반 여부가 실려 있지 않으므로 하네스가
@@ -130,7 +146,9 @@ def main() -> int:
         "--out",
         type=Path,
         default=None,
-        help="회차 기록 출력 경로 (기본: runs/ad_copy_<run_id>.jsonl)",
+        help="회차 기록 출력 경로의 바탕 (기본: runs/ad_copy_<run_id>.jsonl). "
+        "on/off 팔을 같은 분모로 합산하면 안 되므로 실제로는 이 경로의 stem에 "
+        "_on/_off를 붙인 두 파일에 나눠 씁니다",
     )
     parser.add_argument("--limit", type=int, default=None, help="앞에서부터 N건만 (시험 실행용)")
     parser.add_argument("--case", action="append", default=None, help="특정 id만 실행 (반복 가능)")
@@ -165,10 +183,22 @@ def main() -> int:
         print("주의: model 모드인데 ADGEN_MODEL_API_KEY가 비어 있어 모든 호출이 실패로 기록됩니다.")
 
     if args.dry_run:
+        bad = 0
         for c in cases:
+            try:
+                build_request(c, guardrail_applied=True)
+            except ValidationError as exc:
+                print(f"  {c['id']:8} 계약 검증 실패: {exc}")
+                bad += 1
+                continue
             print(
                 f"  {c['id']:8} {c['caseType']:11} {c['guardrailFocus']:22} {c['request']['outputType']}"
             )
+        if bad:
+            print(
+                f"\n{bad}건이 DraftGenerateRequest 계약과 어긋납니다. --yes로 돌리기 전에 골든셋을 고치세요."
+            )
+            return 1
         return 0
     if not args.yes:
         parser.error(
@@ -176,26 +206,41 @@ def main() -> int:
         )
 
     run_id = time.strftime("%Y%m%d-%H%M%S")
-    out_path = args.out or Path(__file__).parent / "runs" / f"ad_copy_{run_id}.jsonl"
-    out_path.parent.mkdir(parents=True, exist_ok=True)
+    base_out = args.out or Path(__file__).parent / "runs" / f"ad_copy_{run_id}.jsonl"
+    base_out.parent.mkdir(parents=True, exist_ok=True)
+    # on/off를 같은 파일에 이어 쓰면 run_metrics.py가 arm을 모르고 guardrailPassed를
+    # 전부 한 리스트로 합산합니다 - 대조군(off) 위반이 배포 설정(on)의 위반으로 보고되고
+    # 표본 수도 두 배로 부풀려집니다. 팔마다 파일을 갈라 이 합산 자체가 나지 않게 합니다
+    # (생성_파이프라인 5.3절, "표본 수와 대조군 결과는 따로 적는다").
+    out_paths: dict[Arm, Path] = {
+        "on": base_out.with_name(f"{base_out.stem}_on{base_out.suffix}"),
+        "off": base_out.with_name(f"{base_out.stem}_off{base_out.suffix}"),
+    }
 
     records: list[dict[str, Any]] = []
-    with out_path.open("w", encoding="utf-8") as f:
+    handles = {arm: path.open("w", encoding="utf-8") for arm, path in out_paths.items()}
+    try:
         for i, case in enumerate(cases, 1):
             for arm in ("on", "off"):
                 record = run_one(case, arm, settings, run_id)
                 records.append(record)
-                f.write(json.dumps(record, ensure_ascii=False) + "\n")
-                f.flush()  # 회차 중간에 죽어도 그때까지 기록은 남습니다
+                handles[arm].write(json.dumps(record, ensure_ascii=False) + "\n")
+                handles[arm].flush()  # 회차 중간에 죽어도 그때까지 기록은 남습니다
             print(f"[{i}/{len(cases)}] {case['id']} 완료")
+    finally:
+        for handle in handles.values():
+            handle.close()
 
     skipped = sum(1 for r in records if "skipped" in r)
     errored = sum(1 for r in records if "error" in r)
     graded = sum(1 for r in records if "guardrailPassed" in r)
     print(
-        f"\n{out_path} 에 {len(records)}줄 기록. 스킵 {skipped}건, 실패 {errored}건, 채점 가능 {graded}건"
+        f"\n{out_paths['on']} (on)와 {out_paths['off']} (off)에 나눠 기록. "
+        f"총 {len(records)}줄. 스킵 {skipped}건, 실패 {errored}건, 채점 가능 {graded}건"
     )
-    print(f"다음: python eval/run_metrics.py --input {out_path}")
+    print("다음: 두 팔을 각각 채점하세요 - 합쳐서 채점하면 대조군 위반이 섞입니다.")
+    print(f"  python eval/run_metrics.py --input {out_paths['on']}")
+    print(f"  python eval/run_metrics.py --input {out_paths['off']}")
     return 0
 
 

--- a/apps/ai-engine/src/ai_engine/draft.py
+++ b/apps/ai-engine/src/ai_engine/draft.py
@@ -71,9 +71,10 @@ def generate_draft(request: DraftGenerateRequest, settings: Settings) -> DraftGe
 def _generate_stub(request: DraftGenerateRequest, settings: Settings) -> DraftGenerateResponse:
     """Fixed single-ad draft, visibly marked.
 
-    ⚠️ The copy is built **only** from `sellingPoint`, which is the guardrail's evidence
-    (`sellingPoint` + `note`). Even a stub must not put a number or a claim on the wire that
-    the input did not carry — the skeleton is where that habit is set.
+    ⚠️ The copy is built **only** from `sellingPoint`, part of the guardrail's evidence
+    (`sellingPoint` + `note` + product name, see `_evidence`). Even a stub must not put a
+    number or a claim on the wire that the input did not carry — the skeleton is where that
+    habit is set.
     """
     if request.output_type == "comic":
         raise NotImplementedError(

--- a/apps/ai-engine/src/ai_engine/models/generation.py
+++ b/apps/ai-engine/src/ai_engine/models/generation.py
@@ -57,9 +57,11 @@ class BriefFillResponse(Base):
 class DraftGenerateRequest(Base):
     """Contract: `components.schemas.DraftGenerateRequest`.
 
-    ⚠️ The evidence for the guardrail is `brief.sellingPoint` plus `brief.note`. `category`
-    and `target` are inferred values and are **not** evidence — grounding a claim in them
-    means grounding it in something the model made up.
+    ⚠️ The evidence for the guardrail is `brief.sellingPoint` plus `brief.note` plus
+    `brief.product_name` (생성_파이프라인 5.2절, added 2026-08-20 so a copy that echoes the
+    product name is not counted as an invented claim). `category` and `target` are inferred
+    values and are **not** evidence — grounding a claim in them means grounding it in
+    something the model made up.
     """
 
     output_type: OutputType


### PR DESCRIPTION
## 📌 변경 개요

**08-25에 `main` 위로 리베이스했습니다** (#224가 스쿼시 머지된 뒤, 이 브랜치가 들고 있던
#224의 리뷰 반영 전 커밋을 빼고 나머지를 `main` 위로 다시 얹었습니다 - Eastar0102 리뷰
지적. `ad_copy.jsonl` g-001과 `README.md` 스키마 절이 옛 내용으로 되돌아가지 않는 것을
확인했습니다).

지표 실측(08-26 ~ 28)의 첫 조각입니다. `run_collect_ad_copy.py`가 `ad_copy.jsonl`(26건,
#224)을 실제로 `draft.generate_draft()`에 태워, `run_metrics.py`가 바로 읽는 가드레일
on/off 대조 회차 기록(JSONL)을 만듭니다. 덤으로, 이 작업 중 발견한 근거 문서 드리프트를
`models/generation.py`에서 고칩니다.

```bash
python eval/run_collect_ad_copy.py --dry-run             # 호출 없이 계획만
python eval/run_collect_ad_copy.py --yes                 # 실행 (스텁이면 요금 0)
```

### on/off 팔 처리

- **on 팔** (`guardrail_applied=True`): `generate_draft`가 이미 검사(+ 위반 시 1회 재생성
  후 재검사)까지 끝낸 결과이므로, 시안이 돌아왔다는 것 자체가 최종 통과입니다.
- **off 팔** (`guardrail_applied=False`): `generate_draft`가 `check_claims`를 아예 안
  부릅니다. 원본 응답에 위반 여부가 안 실려 있으므로 하네스가 **사후에 직접** `check_claims`를
  돌려 `guardrailPassed`를 채웁니다 - `run_metrics.py`의 `RECORD_SCHEMA` 경고와 같은 이유입니다
  (대조군의 원본 상태를 그대로 넣으면 "통과"가 아니라 "검사 안 함"이 통과로 잘못 집계됩니다).
- 근거 문자열은 `draft._evidence()`를 그대로 재사용합니다(재구현하지 않음) - 재구현하면
  이번에 고친 것과 같은 드리프트가 또 생깁니다.

### `models/generation.py` 독스트링 수정

`DraftGenerateRequest`가 "가드레일 근거는 `sellingPoint`+`note`"라고 적힌 채 낡아
있었습니다. 실제로는 `sellingPoint`+`note`+`productName` 셋입니다(2026-08-20 productName
추가, 생성_파이프라인 5.2절 - 사용자가 직접 친 제품명을 우리가 지어낸 걸로 안 세기
위해서입니다). 이 스크립트를 짜다가 `draft._evidence()`의 실제 동작과 어긋난 걸
발견했습니다.

---

## 🔗 관련 이슈

없음. #224(골든셋 PR)의 후속입니다.

---

## 📋 변경 유형

- [x] ✨ 새 기능 / 모듈 추가
- [x] 🐛 버그 수정 (독스트링 드리프트)
- [x] 📝 문서 / 주석

---

## 🧪 테스트 / 검증 방법

`로컬에서 확인함` (2026-08-24, `b442943` 기준 워크트리에서 재현. python3.13 임시 venv,
`pip install -e apps/ai-engine`, `import ai_engine`이 이 레포 경로로 resolve되는 것
확인 후 진행). **on/off를 두 파일로 가른 뒤의 결과로 갱신합니다** - 이전 판은 on/off를
한 파일에 합산하던 버전(`85d3fca`)의 출력이라 Eastar0102 리뷰 지적대로 지금 코드와
어긋나 있었습니다.

```
$ python eval/run_collect_ad_copy.py --dry-run
26건 x 2팔(on/off) = 52회 호출 예정 (mode=stub)
주의: 스텁 모드라 comic 16건은 팔마다 스킵됩니다(구현_범위 1절, 만화 미지원).

$ python eval/run_collect_ad_copy.py --yes --out /tmp/run.jsonl
...
/tmp/run_on.jsonl (on)와 /tmp/run_off.jsonl (off)에 나눠 기록. 총 52줄. 스킵 32건,
실패 0건, 채점 가능 10건

$ python eval/run_metrics.py --input /tmp/run_on.jsonl
  (스텁의 on 팔은 check_claims를 안 불러 guardrailPassed가 비어 있음 -> 전 지표 "측정 안 함")

$ python eval/run_metrics.py --input /tmp/run_off.jsonl
  가드레일 위반 건수
    표본: 10
    위반: 0
```

- comic 16건 x 2팔 = 32건이 스텁 미지원으로 정상 스킵되고(에러 아님), single_ad
  10건 x 2팔 = 20건이 호출되어 on/off 두 파일에 나뉘어 기록되는 것 확인. on 팔은
  스텁이라 `guardrailPassed`가 비어 "측정 안 함"으로, off 팔만 표본 10/위반 0으로
  `run_metrics.py`까지 정상 연결되는 것 확인 - 합산 버그 재현 시나리오(off 5건을
  false로 바꾸면 표본20/위반5)도 두 파일이 애초에 분리돼 있어 더는 재현되지 않음.
- 에러 경로(`ADGEN_GENERATION_MODE=model` + 키 없음)도 크래시 없이 `error` 필드로
  기록되는 것 확인(`--case g-001`로 1건만 실행).
- `--case`로 잘못된 id를 주면 `parser.error`로 즉시 실패하는 것 확인.
- `--dry-run`이 전 케이스에 `DraftGenerateRequest` 계약 검증까지 도는 것 확인
  (`g-003`의 `sellingPoint` -> `sellingPointText`로 바꾼 골든셋에서 종료 코드 `1`).
- **실제 model 모드(요금 발생)로는 안 돌렸습니다.** comic 16건을 실제로 검증하려면
  필요합니다 - 별도로 여쭤보고 진행하겠습니다.

---

## ⚠️ 리뷰어 주의사항

**1. 이 PR은 다섯 지표 중 "가드레일 위반 건수" 한 줄만 채웁니다.** "카피 사실 일치율"은
별도 채점 모델(LLM 판정)이 필요해 범위 밖입니다(PR #217과 같은 이유). "생성 지연"도
안 잽니다 - `draft:generate`는 텍스트만 만들고 이미지를 안 거쳐 "잡 접수 -> 결과 이미지
완료"라는 지표 정의와 다른 걸 재게 되기 때문입니다.

**2. `draft._evidence()`를 "private" 함수인데 그대로 import해서 씁니다** (`draft.py`
noqa 주석 참고). 근거 문자열 조합 규칙을 여기서 다시 적으면, 이번에 고친 것과 같은
드리프트(2026-08-20 변경이 문서 한 곳에 안 반영됨)가 또 생길 수 있어 의도적으로
재사용했습니다. 이 판단에 이견 있으면 알려주세요.

**3. 스텁 모드에서 comic 케이스가 스킵되는 건 이 스크립트의 결함이 아닙니다.**
`_generate_stub`이 애초에 만화형을 안 채웁니다(구현_범위 1절, "the stub is
comic-blind"). comic 16건을 실제로 검증하려면 실물 모드(요금 발생)가 필요합니다.

---

## 💬 기타

`runs/`는 이미 `.gitignore`(202행)에 있어 수집 결과물이 실수로 커밋되지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

