### PR TITLE
fix(backend): 화풍 예시 타입 시험이 파이썬 3.13 이상에서 죽던 것을 고칩니다

### DIFF
--- a/apps/backend/tests/api/test_art_style_static.py
+++ b/apps/backend/tests/api/test_art_style_static.py
@@ -152,13 +152,25 @@ def test_the_type_does_not_depend_on_the_operating_system_mime_table(
     `/etc/mime.types` 도 없습니다. 개발 기계에는 그 파일(윈도우는 레지스트리)이 있어 표가
     채워지므로, `guess_type` 에 맡기면 **배포에서만** `application/octet-stream` 이 나갑니다.
 
-    아래 한 줄이 그 컨테이너 조건을 그대로 만듭니다 - OS 표를 읽지 않은 내장 표만으로
-    `_db` 를 갈아 끼웁니다. 사설 이름을 쓰는 이유는 이것이 재현하려는 조건 자체가
-    "OS 표가 없다" 이고, 공개 API 로는 그 상태를 만들 수 없기 때문입니다.
+    아래가 그 컨테이너 조건을 그대로 만듭니다 - OS 표를 읽지 않은 내장 표로 `_db` 를 갈아
+    끼우고, 그 표에서 `.webp` 도 걷어냅니다. 사설 이름을 쓰는 이유는 이것이 재현하려는 조건
+    자체가 "OS 표가 없다" 이고, 공개 API 로는 그 상태를 만들 수 없기 때문입니다.
+
+    ⚠️ **확장자를 걷어내는 줄을 지우지 마세요.** 파이썬 3.13 부터 `.webp` 가 내장 표에
+    들어왔습니다. 그래서 "내장 표만 남긴다" 만으로는 조건이 만들어지지 않고, 3.13 이상
+    개발 기계에서 이 시험이 **전제 단언에서 먼저 죽습니다** (실측: 3.14.5). 두 앱의
+    `requires-python` 이 `>=3.12` 이므로 그 버전들도 규격 안입니다.
+
+    걷어내는 쪽을 고른 이유는, 버전으로 건너뛰면 **3.13 이상에서는 이 시험이 아무것도
+    재지 않게 되기** 때문입니다. 배포는 `python:3.12-slim` 이라 대상 코드
+    (`mimetypes.add_type`)는 그대로 필요합니다.
     """
-    monkeypatch.setattr(mimetypes, "_db", mimetypes.MimeTypes(filenames=()))
+    db = mimetypes.MimeTypes(filenames=())
+    for table in db.types_map:
+        table.pop(".webp", None)
+    monkeypatch.setattr(mimetypes, "_db", db)
     assert mimetypes.guess_type("style-01-traits.webp")[0] is None, (
-        "이 시험의 전제가 깨졌습니다 - 내장 표에 .webp 가 생겼다면 시험을 지워도 됩니다"
+        "이 시험이 재현하려는 조건은 'OS 표에도 내장 표에도 .webp 가 없다' 입니다"
     )
 
     styles = env / "art-styles"


### PR DESCRIPTION
`test_the_type_does_not_depend_on_the_operating_system_mime_table` 이 **파이썬 3.13 이상 개발 기계에서 전제 단언부터 실패합니다.** 실측은 3.14.5 입니다.

```
FAILED tests/api/test_art_style_static.py::test_the_type_does_not_depend_on_the_operating_system_mime_table
E       assert 'image/webp' is None
```

## 왜 나는가

시험은 컨테이너 조건(OS 표가 없어 `.webp` 를 모른다)을 만들려고 내장 표만으로 `_db` 를 갈아 끼웁니다. 그런데 **파이썬 3.13 부터 `.webp` 가 내장 표에 들어왔습니다.** 갈아 끼워도 여전히 타입이 나오므로 조건 자체가 만들어지지 않습니다.

| | 내장 표의 `.webp` | 결과 |
|---|---|---|
| CI (`python-version: '3.12'`) | 없음 | 통과 |
| 3.13 이상 개발 기계 | **있음** | **실패** |

두 앱의 `requires-python` 이 `>=3.12` 이므로 **3.13 이상도 규격 안**입니다. 환경이 어긋난 것이 아닙니다.

## 왜 급한가

**pre-push 훅이 전량 pytest 라, 3.13 이상을 쓰는 사람은 이 레포에 아무것도 push 할 수 없습니다.** CI 는 3.12 라 계속 초록이어서 드러나지도 않습니다.

실제로 오늘 이것 때문에 #301 의 리뷰 반영분(`AGENTS.md` 의 N26 한 줄)을 머지 전에 올리지 못했습니다.

## 고친 방법

내장 표에서 `.webp` 를 **직접 걷어냅니다.**

```python
db = mimetypes.MimeTypes(filenames=())
for table in db.types_map:
    table.pop(".webp", None)
monkeypatch.setattr(mimetypes, "_db", db)
```

3.12 에서는 없던 키를 지우는 것이라 아무 일도 하지 않고, 3.13 이상에서는 조건이 만들어집니다. **두 버전이 같은 것을 잽니다.**

## 버전으로 건너뛰지 않은 이유

시험 주석이 이렇게 적어 두었습니다.

> 이 시험의 전제가 깨졌습니다 - 내장 표에 .webp 가 생겼다면 시험을 지워도 됩니다

**따르지 않았습니다.** 배포가 `python:3.12-slim` 이라 대상 코드는 그대로 필요하고, `skip` 이든 삭제든 **3.13 이상에서는 이 시험이 아무것도 재지 않게 됩니다.** 그러면 회귀가 CI 에서만 잡히고 개발 중에는 안 보입니다.

## 대상 코드는 건드리지 않았습니다

시험이 여전히 무는지 확인했습니다.

| 변이 | 결과 |
|---|---|
| `main.py` 의 명시 `Content-Type` 설정 제거 (#294 로 되돌리기) | **1건 실패** |
| 복원 | 6건 통과 |

## 검증

backend **334건**, ai-engine **267건**, `mypy` (36 files), `ruff` 전부 통과입니다. 이 브랜치에서 pre-push 훅이 통과한 것 자체가 증상이 사라졌다는 확인입니다.

## 소관

05 파일이라 원래 05 몫입니다. 팀 전체가 push 로 막혀 있고 제출이 내일이라 먼저 올렸습니다 - 되돌리거나 가져가셔도 됩니다.
